### PR TITLE
Fix Android Flutter v2 embedding declaration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,5 +7,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>


### PR DESCRIPTION
## Ursache

`flutter run` bricht mit `Build failed due to use of deleted Android v1 embedding.` ab.

Die `MainActivity` verwendet bereits das aktuelle v2-Embedding (`io.flutter.embedding.android.FlutterActivity`), aber im `AndroidManifest.xml` fehlte die Kennzeichnung des Embeddings.

## Änderung

Ergänzt wurde:

```xml
<meta-data
    android:name="flutterEmbedding"
    android:value="2" />
```

Damit erkennt das Flutter-Tool das Projekt als Android-v2-Embedding-Projekt.

## Prüfung

Der PR enthält bewusst nur diese minimale Änderung am Android-Manifest. Die lokale Ausführung von `flutter run` kann über den GitHub-Connector nicht durchgeführt werden; bitte nach Checkout des Branches erneut lokal testen.