### PR TITLE
Fix Android Gradle toolchain for Flutter build

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -7,7 +7,11 @@ pluginManagement {
     includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
     repositories { google(); mavenCentral(); gradlePluginPortal() }
 }
-plugins { id("dev.flutter.flutter-plugin-loader") version "1.0.0" }
+plugins {
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.7.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+}
 dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS); repositories { google(); mavenCentral() } }
 rootProject.name = "developer_wiki_source_capture"
 include(":app")


### PR DESCRIPTION
Closes #2

## Ursache

Der Android-Unterbau des Projekts war unvollständig versioniert: `android/gradle/wrapper/gradle-wrapper.properties` fehlte und `android/settings.gradle.kts` enthielt keine expliziten Versionen für Android Gradle Plugin und Kotlin Gradle Plugin. Dadurch konnte lokal eine zu neue Gradle-Version verwendet werden. Das gemeldete Fehlerbild (`unable to resolve class groovy.xml.QName` in `flutter.groovy`) passt zu einer bekannten Inkompatibilität älterer Flutter-Gradle-Plugins mit Gradle 9.x.

## Änderung

- Gradle auf `8.10.2` festgeschrieben.
- Android Gradle Plugin auf `8.7.0` festgeschrieben.
- Kotlin Gradle Plugin auf `1.8.22` festgeschrieben.
- Keine Änderung an Dart-/App-Logik.

Die Versionen entsprechen der Flutter-3.29.3-Android-Toolchain, deren SDK-/Target-Konfiguration zur vorhandenen `compileSdk = 35` / `targetSdk = 35`-Konfiguration des Projekts passt.

## Prüfung

- Branch gegen `master` verglichen: genau zwei Android-Builddateien geändert.
- `android/gradle/wrapper/gradle-wrapper.properties` enthält Gradle 8.10.2.
- `android/settings.gradle.kts` enthält die fehlenden AGP-/Kotlin-Plugin-Versionen.

Eine echte lokale Android-Kompilierung kann über den GitHub-Connector nicht ausgeführt werden. Nach Merge bitte lokal prüfen mit:

```powershell
flutter clean
flutter pub get
flutter run
```

## Verbleibende Unsicherheit

Die lokal installierte Flutter-Version und eventuell bereits vorhandene, nicht versionierte Wrapper-Dateien sind über den GitHub-Connector nicht sichtbar. Falls der lokale Flutter-SDK-Stand deutlich neuer oder älter ist, muss die Toolchain nach dem ersten Lauf ggf. gemeinsam angepasst werden.