### PR TITLE
Pin Gradle daemon to Java 21

### DIFF
--- a/android/gradle/gradle-daemon-jvm.properties
+++ b/android/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,2 @@
+# Gradle 8.10.2 cannot run on Java 25. Pin the daemon to a supported LTS JDK.
+toolchainVersion=21


### PR DESCRIPTION
Closes #4

## Ursache

Der Build verwendet Gradle 8.10.2. Laut offizieller Gradle-Kompatibilitätsmatrix kann Gradle 8.10.x auf Java bis einschließlich 23 laufen; Java 25 wird erst ab Gradle 9.1.0 als Runtime unterstützt. Die knappe Fehlermeldung `25.0.2` entspricht daher sehr wahrscheinlich der lokal verwendeten JDK-Version.

Ein Upgrade auf Gradle 9.1.0 ist hier keine geeignete Lösung, weil das zuvor beobachtete `groovy.xml.QName`-Problem gerade durch die Kombination des verwendeten Flutter-Gradle-Plugins mit Gradle 9/Groovy 4 ausgelöst wurde.

## Änderung

Es wird eine versionierte Daemon-JVM-Vorgabe ergänzt:

```properties
# Gradle 8.10.2 cannot run on Java 25. Pin the daemon to a supported LTS JDK.
toolchainVersion=21
```

Gradle 8.10 unterstützt Daemon-JVM-Kriterien; die Datei `gradle/gradle-daemon-jvm.properties` ist dafür vorgesehen und soll laut Gradle-Dokumentation versioniert werden. Damit wird für den Gradle-Daemon Java 21 verlangt, auch wenn auf dem Rechner global ein neueres JDK eingestellt ist.

## Prüfung

- Branch gegen `master` verglichen.
- Genau eine neue Konfigurationsdatei mit zwei Zeilen wird hinzugefügt.
- Keine App-Logik und keine bestehende Android-/Flutter-Konfiguration wird verändert.

Eine echte lokale Android-Kompilierung kann über den GitHub-Connector nicht ausgeführt werden.

Nach Merge bitte lokal prüfen:

```powershell
git pull
flutter clean
flutter pub get
flutter doctor -v
flutter run
```

## Verbleibende Unsicherheit

Der gemeldete Fehler enthält keinen Stacktrace. Die Zuordnung von `25.0.2` zu Java/JDK 25.0.2 ist daher sehr wahrscheinlich, aber nicht lokal verifiziert. Außerdem muss auf dem Rechner ein von Gradle auffindbares JDK 21 vorhanden sein. Falls keines gefunden wird, ist anschließend die lokale Flutter-JDK-Auswahl auf ein installiertes JDK 21 (typischerweise das mit Android Studio gelieferte JDK, sofern Version 21) zu setzen.