### PR TITLE
Fix conflicting Android Gradle plugin versions

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,1 @@
-plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
-}
+// Plugin versions are managed centrally in settings.gradle.kts.


### PR DESCRIPTION
## Zusammenfassung

Behebt den bei `flutter run` auftretenden Konflikt zwischen mehrfach deklarierten Gradle-Plugin-Versionen.

Closes #6

## Ursache

`android/build.gradle.kts` deklarierte `com.android.application` in Version `8.7.3` und `org.jetbrains.kotlin.android` in Version `2.1.0`, während `android/settings.gradle.kts` dieselben Plugins bereits mit `8.7.0` bzw. `1.8.22` zentral verwaltet. Dadurch war AGP `8.7.0` bereits auf dem Classpath, bevor `8.7.3` erneut angefordert wurde.

## Änderung

- redundante Plugin-Deklaration aus `android/build.gradle.kts` entfernt
- `android/settings.gradle.kts` bleibt die einzige Quelle für Plugin-Versionen
- bestehende, durch #2 festgelegte Toolchain bleibt unverändert:
  - Android Gradle Plugin 8.7.0
  - Kotlin Gradle Plugin 1.8.22
  - Gradle 8.10.2

## Prüfungen

- Branch-Konfiguration über den GitHub-Connector erneut gelesen
- `android/build.gradle.kts` enthält keine zweite Plugin-Version mehr
- `android/settings.gradle.kts` enthält weiterhin genau die vorgesehenen zentralen Plugin-Versionen
- `android/gradle/wrapper/gradle-wrapper.properties` verwendet weiterhin Gradle 8.10.2

## Verbleibende Unsicherheit

Ein vollständiger Android-/Flutter-Build kann über den GitHub-Connector nicht lokal ausgeführt werden. Nach dem Merge sollte daher lokal `flutter clean`, `flutter pub get` und `flutter run` ausgeführt werden.