### PR TITLE
Fix Flutter Gradle repository conflict

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -12,6 +12,5 @@ plugins {
     id("com.android.application") version "8.7.0" apply false
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
 }
-dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS); repositories { google(); mavenCentral() } }
 rootProject.name = "developer_wiki_source_capture"
 include(":app")


### PR DESCRIPTION
## Zusammenfassung

Behebt den Fehler beim Anwenden von `dev.flutter.flutter-gradle-plugin`, der durch die Repository-Policy in `android/settings.gradle.kts` ausgelöst wurde.

Closes #8

## Ursache

`android/settings.gradle.kts` setzte `RepositoriesMode.FAIL_ON_PROJECT_REPOS`. Das Flutter-Gradle-Plugin ergänzt beim Anwenden selbst ein Maven-Repository auf Projektebene. Dadurch wurde der Build bereits während der Plugin-Initialisierung abgebrochen.

## Änderung

- `dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS) ... }` entfernt
- vorhandene Plugin-Verwaltung unverändert gelassen
- Toolchain-Versionen unverändert:
  - Android Gradle Plugin 8.7.0
  - Kotlin Gradle Plugin 1.8.22
  - Gradle 8.10.2

## Prüfungen

- `AGENTS.md` vor Änderungen gelesen
- aktuelle `settings.gradle.kts`, `build.gradle.kts` und `app/build.gradle.kts` analysiert
- Branch-Konfiguration nach der Änderung erneut über den GitHub-Connector gelesen
- die konfliktverursachende `FAIL_ON_PROJECT_REPOS`-Policy ist nicht mehr vorhanden
- Flutter-Plugin- und Toolchain-Konfiguration bleiben unverändert

## Verbleibende Unsicherheit

Der GitHub-Connector kann keinen vollständigen lokalen Android-/Flutter-Build ausführen. Nach dem Merge sollte daher lokal mit `flutter clean`, `flutter pub get` und `flutter run` verifiziert werden.