### PR TITLE
Add missing Android launcher icon

### DIFF
--- a/android/app/src/main/res/mipmap/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#3F51B5"
+        android:pathData="M4,4h40v40H4z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M14,11h14l6,6v20H14zM27,13v6h6M18,23h12v2H18zM18,28h12v2H18zM18,33h9v2H18z" />
+</vector>


### PR DESCRIPTION
## Zusammenfassung

Behebt den Android-Resource-Linking-Fehler, weil das Manifest auf `@mipmap/ic_launcher` verweist, die Ressource im Repository aber fehlte.

Closes #10

## Ursache

`android/app/src/main/AndroidManifest.xml` enthält `android:icon="@mipmap/ic_launcher"`. Unter `android/app/src/main/res` existierte jedoch nur `values/`; eine `mipmap/ic_launcher`-Ressource war nicht vorhanden. AAPT konnte deshalb die Ressourcen nicht verlinken.

## Änderung

- neue Ressource `android/app/src/main/res/mipmap/ic_launcher.xml` ergänzt
- Manifest unverändert gelassen
- keine App-Logik geändert

## Prüfungen

- `AGENTS.md` vor Änderungen gelesen
- Manifest und Ressourcenstruktur über den GitHub-Connector geprüft
- neue Ressource nach dem Commit erneut aus dem Branch gelesen
- Referenzname und Ressourcename stimmen nun überein: `@mipmap/ic_launcher`

## Verbleibende Unsicherheit

Der vollständige lokale Android-/Flutter-Build kann über den GitHub-Connector nicht ausgeführt werden. Nach dem Merge sollte lokal mit `flutter clean`, `flutter pub get` und `flutter run` verifiziert werden.