### PR TITLE
Fix Kotlin JVM target compatibility

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,22 @@
-plugins { id("com.android.application"); id("org.jetbrains.kotlin.android"); id("dev.flutter.flutter-gradle-plugin") }
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("dev.flutter.flutter-gradle-plugin")
+}
 
 android {
     namespace = "de.huluvu.developer_wiki_source_capture"
     compileSdk = 35
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
     defaultConfig {
         applicationId = "de.huluvu.developer_wiki_source_capture"
         minSdk = 23
@@ -12,4 +26,6 @@ android {
     }
 }
 
-flutter { source = "../.." }
+flutter {
+    source = "../.."
+}


### PR DESCRIPTION
## Zusammenfassung

Behebt den Fehler `Unknown Kotlin JVM target: 21` bei `:app:compileDebugKotlin`.

Closes #12

## Ursache

Der Gradle-Daemon läuft für dieses Projekt bewusst mit JDK 21. In `android/app/build.gradle.kts` war jedoch keine explizite Java-/Kotlin-Bytecodezielversion konfiguriert. Dadurch wurde JVM-Target 21 an die Kotlin-Kompilierung weitergereicht, obwohl das im Projekt festgeschriebene Kotlin Gradle Plugin 1.8.22 dieses Ziel nicht unterstützt.

## Änderung

- Java-`sourceCompatibility` auf 17 gesetzt
- Java-`targetCompatibility` auf 17 gesetzt
- Kotlin-`jvmTarget` auf 17 gesetzt
- Gradle-Daemon bleibt auf JDK 21
- keine Plugin-Versionen und keine App-Logik geändert

## Prüfungen

- `AGENTS.md` vor Änderungen gelesen
- `android/settings.gradle.kts` und `android/app/build.gradle.kts` analysiert
- betroffene Build-Datei nach dem Commit erneut über den GitHub-Connector gelesen
- Java- und Kotlin-Targets stimmen nun auf 17 überein
- AGP 8.7 dokumentiert JDK 17 als Mindest-/Standard-JDK, daher ist Java 17 ein konservatives kompatibles Bytecodeziel

## Verbleibende Unsicherheit

Der vollständige lokale Android-/Flutter-Build kann über den GitHub-Connector nicht ausgeführt werden. Nach dem Merge sollte lokal mit `flutter clean`, `flutter pub get` und `flutter run` verifiziert werden.