### PR TITLE
Restore Flutter Android build output path

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,1 +1,28 @@
-// Plugin versions are managed centrally in settings.gradle.kts.
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.layout.buildDirectory.value(
+    rootProject.layout.buildDirectory
+        .dir("../../build")
+        .get()
+)
+
+subprojects {
+    project.layout.buildDirectory.value(
+        rootProject.layout.buildDirectory
+            .dir(project.name)
+            .get()
+    )
+}
+
+subprojects {
+    project.evaluationDependsOn(":app")
+}
+
+tasks.register<Delete>("clean") {
+    delete(rootProject.layout.buildDirectory)
+}


### PR DESCRIPTION
## Zusammenfassung

Behebt den Fall, dass `assembleDebug` erfolgreich läuft, Flutter das erzeugte APK anschließend aber nicht findet.

Closes #14

## Ursache

`android/build.gradle.kts` enthielt nur noch einen Kommentar. Dadurch fehlte die Flutter-übliche Weiterleitung der Gradle-Buildverzeichnisse auf das projektweite `../../build`. Gradle konnte deshalb erfolgreich unter dem Android-Subprojekt bauen, während Flutter anschließend im projektweiten `build` nach dem APK suchte.

## Änderung

- Flutter-übliche Repository-Konfiguration wiederhergestellt
- `rootProject.layout.buildDirectory` auf `../../build` gesetzt
- Build-Verzeichnisse der Subprojects unter das gemeinsame Build-Verzeichnis gelegt
- `evaluationDependsOn(":app")` wiederhergestellt
- `clean`-Task wiederhergestellt
- keine Plugin-Versionen und keine App-Logik geändert

## Prüfungen

- `AGENTS.md` vor Änderungen gelesen
- aktuelle `android/build.gradle.kts` analysiert
- offizielle Flutter-Android-Konfiguration als Referenz geprüft
- Branch-Datei nach dem Commit erneut über den GitHub-Connector gelesen
- gemeinsames Build-Verzeichnis zeigt nun wieder auf das von Flutter erwartete Projekt-`build`

## Verbleibende Unsicherheit

Der GitHub-Connector kann den lokal erzeugten APK-Pfad nicht verifizieren. Nach dem Merge sollte lokal mit `flutter clean`, `flutter pub get` und `flutter run` geprüft werden.