### PR TITLE
Add importable master branch protection ruleset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,45 @@ Wenn der Benutzer die Umsetzung einer Story beauftragt, ist grundsätzlich folge
     - Die durchgeführten Prüfungen nennen.
     - Auf offene Punkte oder notwendige lokale Prüfungen hinweisen.
 
+## Rebase und Aktualisierung von Arbeitsbranches
+
+Rebase darf verwendet werden, um einen Story-, Bugfix- oder sonstigen Arbeitsbranch vor dem Merge auf den aktuellen Stand von `master` zu bringen. Dabei gelten folgende Regeln:
+
+1. `master` selbst wird niemals rebased oder anderweitig durch History-Rewriting verändert.
+    - Rebase findet ausschließlich auf Arbeitsbranches statt.
+    - Ein bereits gemergter Branch wird nicht nachträglich rebased.
+
+2. Vor einem Rebase den aktuellen Zielstand und den Branch-Kontext prüfen.
+    - Zuerst den aktuellen Stand von `master` abrufen und sicherstellen, dass der richtige Arbeitsbranch aktiv ist.
+    - Prüfen, ob der Branch ausschließlich zu dem eigenen Pull Request gehört oder von anderen Personen bzw. Automationen mitverwendet wird.
+    - Einen geteilten oder von anderen aktiv verwendeten Branch nicht ohne ausdrückliche Zustimmung rebasen, da Rebase die Commit-Historie umschreibt.
+
+3. Rebase bevorzugen, wenn ein Arbeitsbranch vor dem Merge hinter `master` liegt und eine lineare Historie sinnvoll ist.
+    - Den Arbeitsbranch auf den aktuellen `master` rebasen, statt unnötige Merge-Commits nur zur Branch-Aktualisierung zu erzeugen.
+    - Rebase nicht als Selbstzweck verwenden; wenn kein Aktualisierungsbedarf besteht, ist kein Rebase erforderlich.
+
+4. Konflikte bewusst und nachvollziehbar auflösen.
+    - Bei jedem Konflikt prüfen, welche Änderung fachlich erhalten bleiben muss.
+    - Konflikte nicht pauschal mit `ours` oder `theirs` auflösen, wenn dadurch fachliche Änderungen verloren gehen könnten.
+    - Wenn die korrekte Auflösung unklar ist, Rebase abbrechen statt zu raten.
+    - Nach Konfliktauflösung den Rebase vollständig abschließen und sicherstellen, dass keine Konfliktmarker im Repository verbleiben.
+
+5. Nach einem Rebase die betroffenen Prüfungen erneut ausführen.
+    - Mindestens die für die Story oder den Bugfix relevanten Tests und statischen Prüfungen wiederholen.
+    - Bei Flutter-Änderungen insbesondere `dart format`, `flutter analyze` und die relevanten Tests erneut ausführen, sofern sie durch die Änderung betroffen sein können.
+    - Der Pull Request darf nach einem Rebase erst als mergefähig betrachtet werden, wenn diese Prüfungen wieder erfolgreich sind.
+
+6. Einen bereits veröffentlichten Arbeitsbranch nur kontrolliert aktualisieren.
+    - Da Rebase Commit-SHAs verändert, darf ein bereits gepushter Branch nur mit einem sicheren Lease aktualisiert werden.
+    - Dafür ausschließlich `git push --force-with-lease` verwenden.
+    - `git push --force` ist für Arbeitsbranches dieses Projekts nicht zulässig.
+    - Wenn `--force-with-lease` wegen zwischenzeitlicher fremder Änderungen fehlschlägt, diese Änderungen zuerst prüfen und nicht durch einen erzwungenen Push überschreiben.
+
+7. Rebase und Branchschutz müssen zusammenpassen.
+    - Der geschützte `master` wird ausschließlich über Pull Requests verändert.
+    - Force Pushes auf `master` bleiben durch das Ruleset verboten.
+    - History-Rewriting ist nur auf dem zugehörigen Arbeitsbranch und nur nach den oben genannten Regeln zulässig.
+
 ## Architekturleitplanken
 
 Für die Weiterentwicklung der App gelten zusätzlich folgende Leitplanken:

--- a/gh-rulesets/README.md
+++ b/gh-rulesets/README.md
@@ -1,0 +1,29 @@
+# GitHub Rulesets
+
+Dieses Verzeichnis enthält importierbare GitHub-Rulesets für das Repository.
+
+## `master-protection.json`
+
+Das Ruleset schützt den Branch `master` mit bewusst einfachen Regeln, die zu einem persönlichen Ein-Personen-Projekt passen:
+
+- Änderungen an `master` müssen über einen Pull Request erfolgen.
+- Es ist keine fremde Freigabe vorgeschrieben, da das Repository von einer Person gepflegt wird.
+- Offene Review-Unterhaltungen müssen vor dem Merge aufgelöst sein.
+- `master` darf nicht gelöscht werden.
+- Force Pushes auf `master` sind verboten.
+
+Bewusst noch nicht enthalten sind verpflichtende Status Checks. Solche Checks sollten erst dann in das Ruleset aufgenommen werden, wenn stabile, dauerhaft verfügbare CI-Checks mit festen Namen existieren. Andernfalls könnte ein umbenannter oder entfernter Check den Branch unnötig blockieren.
+
+Ebenso werden derzeit keine signierten Commits vorgeschrieben, damit lokale Entwicklung, GitHub-Web-Merges und automatisierte/assistierte Änderungen nicht unnötig eingeschränkt werden.
+
+## Import in GitHub
+
+1. Repository auf GitHub öffnen.
+2. `Settings` → `Rules` → `Rulesets` öffnen.
+3. `New ruleset` → `Import a ruleset` wählen.
+4. `gh-rulesets/master-protection.json` auswählen.
+5. Das importierte Ruleset prüfen.
+6. Sicherstellen, dass ausschließlich `refs/heads/master` betroffen ist.
+7. Ruleset erstellen bzw. aktivieren.
+
+Nach dem Import sollten Änderungen am geschützten Branch ausschließlich über Pull Requests erfolgen.

--- a/gh-rulesets/master-protection.json
+++ b/gh-rulesets/master-protection.json
@@ -1,0 +1,31 @@
+{
+  "name": "Protect master",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/master"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "dismiss_stale_reviews_on_push": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}


### PR DESCRIPTION
## Änderung

Fügt unter `gh-rulesets/` ein importierbares GitHub-Ruleset zum Schutz des `master`-Branches sowie eine kurze Dokumentation hinzu. Zusätzlich wird `AGENTS.md` um verbindliche Regeln für Rebase und die Aktualisierung von Arbeitsbranches ergänzt.

Das Ruleset erzwingt:
- Änderungen an `master` nur über Pull Requests,
- Auflösung offener Review-Unterhaltungen vor dem Merge,
- Schutz vor Löschen des Branches,
- Schutz vor Force Pushes.

Bewusst nicht enthalten sind verpflichtende fremde Reviews, weil das Repository als persönliches Ein-Personen-Projekt betrieben wird. Ebenso werden noch keine festen Status-Checks verlangt, solange keine dauerhaft stabil benannten CI-Checks existieren.

## Rebase-Regeln

Die ergänzten Regeln in `AGENTS.md` legen insbesondere fest:
- `master` selbst wird niemals rebased oder per History-Rewrite verändert,
- Rebase findet nur auf Story-, Bugfix- oder anderen Arbeitsbranches statt,
- Arbeitsbranches dürfen auf den aktuellen `master` rebased werden, wenn dies vor dem Merge sinnvoll ist,
- geteilte Branches werden nicht ohne ausdrückliche Zustimmung rebased,
- Konflikte werden fachlich geprüft und nicht pauschal mit `ours`/`theirs` aufgelöst,
- nach einem Rebase werden relevante Tests und statische Prüfungen erneut ausgeführt,
- für bereits veröffentlichte Arbeitsbranches ist ausschließlich `git push --force-with-lease` zulässig,
- `git push --force` ist nicht zulässig,
- schlägt `--force-with-lease` wegen zwischenzeitlicher Änderungen fehl, werden diese Änderungen zuerst geprüft statt überschrieben.

## Verwendung

Die Datei `gh-rulesets/master-protection.json` kann über `Settings → Rules → Rulesets → New ruleset → Import a ruleset` in GitHub importiert werden.

## Prüfung

Das JSON orientiert sich am von GitHub dokumentierten/importierbaren Ruleset-Format und an den offiziellen `github/ruleset-recipes`. Ziel ist ausschließlich `refs/heads/master`. Die Änderung an `AGENTS.md` ist reine Prozessdokumentation und hat keine Auswirkungen auf Build oder Laufzeit.