### PR TITLE
Implement personal wiki connection setup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,72 @@
 import 'package:flutter/material.dart';
+
+import 'models/wiki_configuration.dart';
+import 'screens/settings_screen.dart';
 import 'screens/source_form_screen.dart';
+import 'services/configuration_service.dart';
 
 void main() => runApp(const WikiSourceApp());
 
-class WikiSourceApp extends StatelessWidget {
+class WikiSourceApp extends StatefulWidget {
   const WikiSourceApp({super.key});
+
   @override
-  Widget build(BuildContext context) => MaterialApp(
+  State<WikiSourceApp> createState() => _WikiSourceAppState();
+}
+
+class _WikiSourceAppState extends State<WikiSourceApp> {
+  final _configurationService = ConfigurationService();
+  late Future<WikiConfiguration> _configuration;
+
+  @override
+  void initState() {
+    super.initState();
+    _reloadConfiguration();
+  }
+
+  void _reloadConfiguration() {
+    _configuration = _configurationService.load();
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Developer Wiki Quellen',
       theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
-      home: const SourceFormScreen());
+      home: FutureBuilder<WikiConfiguration>(
+        future: _configuration,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (snapshot.hasError) {
+            return Scaffold(
+              body: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(
+                    'Konfiguration konnte nicht geladen werden: ${snapshot.error}',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            );
+          }
+          if (snapshot.data?.isComplete == true) {
+            return const SourceFormScreen();
+          }
+          return SettingsScreen(
+            isSetup: true,
+            onConfigured: _reloadConfiguration,
+          );
+        },
+      ),
+    );
+  }
 }

--- a/lib/models/wiki_configuration.dart
+++ b/lib/models/wiki_configuration.dart
@@ -1,0 +1,48 @@
+class WikiConfiguration {
+  const WikiConfiguration({
+    required this.repositoryUrl,
+    required this.token,
+  });
+
+  static const defaultRepositoryUrl =
+      'https://github.com/Huluvu424242/Developer-Wiki';
+
+  final String repositoryUrl;
+  final String token;
+
+  bool get isComplete =>
+      repositoryUrl.trim().isNotEmpty && token.trim().isNotEmpty;
+}
+
+class GitHubRepository {
+  const GitHubRepository({required this.owner, required this.name});
+
+  final String owner;
+  final String name;
+
+  static GitHubRepository parse(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      throw const FormatException('Repository-Angabe fehlt.');
+    }
+
+    final normalized = trimmed.startsWith('http://') ||
+            trimmed.startsWith('https://')
+        ? trimmed
+        : 'https://github.com/$trimmed';
+    final uri = Uri.tryParse(normalized);
+    if (uri == null || uri.host.toLowerCase() != 'github.com') {
+      throw const FormatException('Bitte ein GitHub-Repository angeben.');
+    }
+
+    final segments = uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
+    if (segments.length != 2) {
+      throw const FormatException(
+          'Repository als https://github.com/owner/repo oder owner/repo angeben.');
+    }
+
+    return GitHubRepository(owner: segments[0], name: segments[1]);
+  }
+
+  String get url => 'https://github.com/$owner/$name';
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,68 +1,236 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/wiki_configuration.dart';
+import '../services/configuration_service.dart';
 import '../services/github_service.dart';
 
 class SettingsScreen extends StatefulWidget {
-  const SettingsScreen({super.key});
+  const SettingsScreen({
+    super.key,
+    this.isSetup = false,
+    this.onConfigured,
+  });
+
+  final bool isSetup;
+  final VoidCallback? onConfigured;
+
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  final storage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true));
-  final controller = TextEditingController();
-  bool busy = false, obscure = true;
+  final _repositoryController = TextEditingController();
+  final _tokenController = TextEditingController();
+  final _configurationService = ConfigurationService();
+
+  bool _busy = false;
+  bool _obscure = true;
+  bool _connectionVerified = false;
+  String? _status;
+  bool _statusIsError = false;
+
   @override
   void initState() {
     super.initState();
-    storage.read(key: 'github_pat').then((v) {
-      if (mounted) controller.text = v ?? '';
+    _repositoryController.addListener(_invalidateVerification);
+    _tokenController.addListener(_invalidateVerification);
+    _load();
+  }
+
+  Future<void> _load() async {
+    final configuration = await _configurationService.load();
+    if (!mounted) {
+      return;
+    }
+    _repositoryController.text = configuration.repositoryUrl;
+    _tokenController.text = configuration.token;
+  }
+
+  void _invalidateVerification() {
+    if (!_connectionVerified && _status == null) {
+      return;
+    }
+    setState(() {
+      _connectionVerified = false;
+      _status = null;
+      _statusIsError = false;
     });
   }
 
-  Future<void> save() async {
-    setState(() => busy = true);
+  Future<void> _testConnection() async {
+    final token = _tokenController.text.trim();
+    if (token.isEmpty) {
+      _setStatus('Bitte zuerst ein Fine-grained PAT eingeben.', isError: true);
+      return;
+    }
+
+    GitHubRepository repository;
     try {
-      final token = controller.text.trim();
-      final login = await GitHubService(token).login();
-      await storage.write(key: 'github_pat', value: token);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Gespeichert – verbunden als $login')));
-        Navigator.pop(context, true);
+      repository = GitHubRepository.parse(_repositoryController.text);
+    } on FormatException catch (error) {
+      _setStatus(error.message.toString(), isError: true);
+      return;
+    }
+
+    setState(() {
+      _busy = true;
+      _status = 'Verbindung wird geprüft …';
+      _statusIsError = false;
+      _connectionVerified = false;
+    });
+
+    try {
+      final login = await GitHubService(
+        token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).verifyRepositoryAccess();
+      if (!mounted) {
+        return;
       }
-    } catch (e) {
-      if (mounted)
-        ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Verbindung fehlgeschlagen: $e')));
+      setState(() {
+        _connectionVerified = true;
+        _status = 'Verbindung erfolgreich – angemeldet als $login.';
+        _statusIsError = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _setStatus(
+        'Zugriff fehlgeschlagen. Token, Repository und Berechtigungen prüfen: '
+        '$error',
+        isError: true,
+      );
     } finally {
-      if (mounted) setState(() => busy = false);
+      if (mounted) {
+        setState(() => _busy = false);
+      }
     }
   }
 
+  Future<void> _save() async {
+    if (!_connectionVerified) {
+      _setStatus('Bitte die Verbindung vor dem Speichern erfolgreich testen.',
+          isError: true);
+      return;
+    }
+
+    final repository = GitHubRepository.parse(_repositoryController.text);
+    setState(() => _busy = true);
+    try {
+      await _configurationService.save(
+        WikiConfiguration(
+          repositoryUrl: repository.url,
+          token: _tokenController.text.trim(),
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      widget.onConfigured?.call();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Wiki-Verbindung gespeichert.')),
+      );
+      if (!widget.isSetup && Navigator.canPop(context)) {
+        Navigator.pop(context, true);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  void _setStatus(String message, {required bool isError}) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _status = message;
+      _statusIsError = isError;
+      if (isError) {
+        _connectionVerified = false;
+      }
+    });
+  }
+
   @override
-  Widget build(BuildContext context) => Scaffold(
-      appBar: AppBar(title: const Text('Einstellungen')),
-      body: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(children: [
-            TextField(
-                controller: controller,
-                obscureText: obscure,
-                decoration: InputDecoration(
-                    labelText: 'GitHub Fine-grained PAT',
-                    helperText:
-                        'Benötigt Issues: Read and write für Developer-Wiki.',
-                    suffixIcon: IconButton(
-                        onPressed: () => setState(() => obscure = !obscure),
-                        icon: Icon(obscure
-                            ? Icons.visibility
-                            : Icons.visibility_off)))),
+  void dispose() {
+    _repositoryController
+      ..removeListener(_invalidateVerification)
+      ..dispose();
+    _tokenController
+      ..removeListener(_invalidateVerification)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: !widget.isSetup,
+        title: Text(widget.isSetup ? 'Developer Wiki – Einrichtung' : 'Einstellungen'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          TextField(
+            controller: _repositoryController,
+            enabled: !_busy,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              labelText: 'GitHub Wiki',
+              helperText: 'Repository-URL oder owner/repo',
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _tokenController,
+            enabled: !_busy,
+            obscureText: _obscure,
+            enableSuggestions: false,
+            autocorrect: false,
+            decoration: InputDecoration(
+              labelText: 'Fine-grained PAT',
+              helperText: 'Das Token wird nur im geschützten lokalen Speicher abgelegt.',
+              suffixIcon: IconButton(
+                tooltip: _obscure ? 'Token anzeigen' : 'Token ausblenden',
+                onPressed: _busy ? null : () => setState(() => _obscure = !_obscure),
+                icon: Icon(_obscure ? Icons.visibility : Icons.visibility_off),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          FilledButton.tonalIcon(
+            onPressed: _busy ? null : _testConnection,
+            icon: const Icon(Icons.link),
+            label: const Text('Verbindung testen'),
+          ),
+          if (_status != null) ...[
             const SizedBox(height: 16),
-            FilledButton.icon(
-                onPressed: busy ? null : save,
-                icon: const Icon(Icons.lock),
-                label: Text(busy ? 'Prüfe …' : 'Prüfen und sicher speichern')),
-          ])));
+            Semantics(
+              liveRegion: true,
+              child: Text(
+                _status!,
+                style: TextStyle(
+                  color: _statusIsError
+                      ? Theme.of(context).colorScheme.error
+                      : null,
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 20),
+          FilledButton.icon(
+            onPressed: _busy || !_connectionVerified ? null : _save,
+            icon: const Icon(Icons.save),
+            label: const Text('Speichern'),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/services/configuration_service.dart
+++ b/lib/services/configuration_service.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/wiki_configuration.dart';
+
+class ConfigurationService {
+  ConfigurationService({FlutterSecureStorage? storage})
+      : _storage = storage ??
+            const FlutterSecureStorage(
+              aOptions: AndroidOptions(encryptedSharedPreferences: true),
+            );
+
+  static const _tokenKey = 'github_pat';
+  static const _repositoryKey = 'wiki_repository_url';
+
+  final FlutterSecureStorage _storage;
+
+  Future<WikiConfiguration> load() async {
+    final token = await _storage.read(key: _tokenKey) ?? '';
+    final repositoryUrl = await _storage.read(key: _repositoryKey) ??
+        WikiConfiguration.defaultRepositoryUrl;
+    return WikiConfiguration(repositoryUrl: repositoryUrl, token: token);
+  }
+
+  Future<void> save(WikiConfiguration configuration) async {
+    await _storage.write(
+      key: _repositoryKey,
+      value: configuration.repositoryUrl.trim(),
+    );
+    await _storage.write(
+      key: _tokenKey,
+      value: configuration.token.trim(),
+    );
+  }
+}

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -1,54 +1,89 @@
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
+
 import '../models/source_template.dart';
 
 class GitHubService {
-  GitHubService(this.token,
-      {this.owner = 'Huluvu424242', this.repo = 'Developer-Wiki'});
-  final String token, owner, repo;
+  GitHubService(
+    this.token, {
+    this.owner = 'Huluvu424242',
+    this.repo = 'Developer-Wiki',
+  });
+
+  final String token;
+  final String owner;
+  final String repo;
+
   Map<String, String> get _headers => {
         'Accept': 'application/vnd.github+json',
         'Authorization': 'Bearer $token',
-        'X-GitHub-Api-Version': '2022-11-28'
+        'X-GitHub-Api-Version': '2022-11-28',
       };
 
-  Future<String> createIssue(
-      {required String title, required String body}) async {
+  Future<String> createIssue({
+    required String title,
+    required String body,
+  }) async {
     final response = await http.post(
-        Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
-        headers: {..._headers, 'Content-Type': 'application/json'},
-        body: jsonEncode({
-          'title': title,
-          'body': body,
-          'labels': ['quelle']
-        }));
-    if (response.statusCode != 201) throw Exception(_message(response));
+      Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
+      headers: {..._headers, 'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'title': title,
+        'body': body,
+        'labels': ['quelle'],
+      }),
+    );
+    if (response.statusCode != 201) {
+      throw Exception(_message(response));
+    }
     return (jsonDecode(response.body) as Map<String, dynamic>)['html_url']
         as String;
   }
 
   Future<String> login() async {
-    final response = await http.get(Uri.parse('https://api.github.com/user'),
-        headers: _headers);
-    if (response.statusCode != 200) throw Exception(_message(response));
+    final response = await http.get(
+      Uri.parse('https://api.github.com/user'),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
     return (jsonDecode(response.body) as Map<String, dynamic>)['login']
         as String;
   }
 
+  Future<String> verifyRepositoryAccess() async {
+    final loginName = await login();
+    final response = await http.get(
+      Uri.parse('https://api.github.com/repos/$owner/$repo'),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
+    return loginName;
+  }
+
   static String issueBody(
-          SourceTemplate template, Map<String, String> values) =>
+    SourceTemplate template,
+    Map<String, String> values,
+  ) =>
       template.fields
-          .where((f) => (values[f.id] ?? '').trim().isNotEmpty)
-          .map((f) => '### ${f.label}\n\n${values[f.id]!.trim()}')
+          .where((field) => (values[field.id] ?? '').trim().isNotEmpty)
+          .map(
+            (field) =>
+                '### ${field.label}\n\n${values[field.id]!.trim()}',
+          )
           .join('\n\n');
 
-  static String _message(http.Response r) {
+  static String _message(http.Response response) {
     try {
-      return (jsonDecode(r.body) as Map<String, dynamic>)['message']
+      return (jsonDecode(response.body) as Map<String, dynamic>)['message']
               ?.toString() ??
-          'HTTP ${r.statusCode}';
+          'HTTP ${response.statusCode}';
     } catch (_) {
-      return 'HTTP ${r.statusCode}';
+      return 'HTTP ${response.statusCode}';
     }
   }
 }

--- a/test/wiki_configuration_test.dart
+++ b/test/wiki_configuration_test.dart
@@ -1,0 +1,50 @@
+import 'package:developer_wiki_source_capture/models/wiki_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GitHubRepository.parse', () {
+    test('accepts full GitHub repository URL', () {
+      final repository = GitHubRepository.parse(
+        'https://github.com/Huluvu424242/Developer-Wiki',
+      );
+
+      expect(repository.owner, 'Huluvu424242');
+      expect(repository.name, 'Developer-Wiki');
+      expect(
+        repository.url,
+        'https://github.com/Huluvu424242/Developer-Wiki',
+      );
+    });
+
+    test('accepts owner/repo shorthand', () {
+      final repository = GitHubRepository.parse('example/wiki');
+
+      expect(repository.owner, 'example');
+      expect(repository.name, 'wiki');
+    });
+
+    test('rejects non GitHub URLs', () {
+      expect(
+        () => GitHubRepository.parse('https://example.org/example/wiki'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  test('configuration is complete only with repository and token', () {
+    expect(
+      const WikiConfiguration(
+        repositoryUrl: WikiConfiguration.defaultRepositoryUrl,
+        token: 'token',
+      ).isComplete,
+      isTrue,
+    );
+    expect(
+      const WikiConfiguration(
+        repositoryUrl: WikiConfiguration.defaultRepositoryUrl,
+        token: '',
+      ).isComplete,
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
Closes #17

## Umsetzung
- zentrale Wiki-Konfiguration mit editierbarer Repository-Angabe und Default `https://github.com/Huluvu424242/Developer-Wiki`
- Fine-grained PAT weiterhin ausschließlich über `flutter_secure_storage`
- Ersteinrichtung beim App-Start, solange Repository/PAT nicht vollständig gespeichert sind
- getrennte Aktion `Verbindung testen` für Token- und Repository-Zugriff
- verständlicher Erfolgs-/Fehlerstatus und Ein-/Ausblenden des PAT
- Speicherung erst nach erfolgreichem Verbindungstest
- Repository-Parsing als UI-unabhängiges Modell und Konfigurationszugriff als eigener Service

## Architektur
Die UI kennt keine GitHub-Header oder API-Payloads. Persistenz ist in `ConfigurationService`, GitHub-Zugriff in `GitHubService` und Repository-Parsing im Modell gekapselt. Bestehende Issue-Erstellung bleibt für die nachgelagerte Story #19 unverändert kompatibel.

## Prüfungen
- Akzeptanzkriterien von #17 gegen die Implementierung geprüft
- bestehender GitHub-Service-Test bleibt unverändert erhalten
- neue Unit-Tests für Repository-Parsing und Vollständigkeit der Konfiguration ergänzt
- Branch-Diff gegen `master` geprüft; ausschließlich Story-17-Dateien geändert

`dart format`, `flutter analyze` und `flutter test` können über den verbundenen GitHub-Connector nicht lokal ausgeführt werden. Vor dem Merge sollten sie daher lokal bzw. durch CI ausgeführt werden. Der zuletzt vom Benutzer gemeldete Baseline-Stand war: Tests erfolgreich, Analyse nur mit bestehenden `curly_braces_in_flow_control_structures`-Infos.

## Offene Punkte
- Die eigentliche Quellen-Issue-Erstellung verwendet bis Story #19 weiterhin den bisherigen Default-Pfad. #17 stellt zunächst die zentrale Konfiguration und Verbindungsprüfung bereit.
