### PR TITLE
Add home screen with source selection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'models/wiki_configuration.dart';
+import 'screens/home_screen.dart';
 import 'screens/settings_screen.dart';
-import 'screens/source_form_screen.dart';
 import 'services/configuration_service.dart';
 
 void main() => runApp(const WikiSourceApp());
@@ -59,7 +59,7 @@ class _WikiSourceAppState extends State<WikiSourceApp> {
             );
           }
           if (snapshot.data?.isComplete == true) {
-            return const SourceFormScreen();
+            return const HomeScreen();
           }
           return SettingsScreen(
             isSetup: true,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../models/source_template.dart';
+import 'settings_screen.dart';
+import 'source_form_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key, this.onImportRequested});
+
+  final VoidCallback? onImportRequested;
+
+  void _openSource(BuildContext context, SourceTemplate template) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SourceFormScreen(initialTemplate: template),
+      ),
+    );
+  }
+
+  void _openSettings(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SettingsScreen()),
+    );
+  }
+
+  void _requestImport(BuildContext context) {
+    if (onImportRequested != null) {
+      onImportRequested!();
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Der Wiki-Import wird in Story #21 umgesetzt.'),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Developer Wiki'),
+        actions: [
+          IconButton(
+            tooltip: 'Einstellungen öffnen',
+            onPressed: () => _openSettings(context),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Neue Quelle erfassen',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          const Text('Wähle die passende Quellenart aus.'),
+          const SizedBox(height: 16),
+          ...sourceTemplates.map(
+            (template) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Card(
+                child: ListTile(
+                  minVerticalPadding: 16,
+                  title: Text(template.name),
+                  subtitle: Text(template.description),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _openSource(context, template),
+                ),
+              ),
+            ),
+          ),
+          const Divider(height: 32),
+          FilledButton.tonalIcon(
+            onPressed: () => _requestImport(context),
+            icon: const Icon(Icons.sync),
+            label: const Text('Quellen ins Wiki importieren'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import '../models/source_template.dart';
 import '../services/github_service.dart';
 import 'settings_screen.dart';
 
 class SourceFormScreen extends StatefulWidget {
-  const SourceFormScreen({super.key});
+  const SourceFormScreen({
+    super.key,
+    this.initialTemplate,
+  });
+
+  final SourceTemplate? initialTemplate;
+
   @override
   State<SourceFormScreen> createState() => _SourceFormScreenState();
 }
@@ -14,119 +21,192 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   final key = GlobalKey<FormState>();
   final title = TextEditingController();
   final storage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true));
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
+
   @override
   void initState() {
     super.initState();
-    _select(sourceTemplates.first);
+    _select(widget.initialTemplate ?? sourceTemplates.first);
   }
 
   void _select(SourceTemplate next) {
     template = next;
-    for (final c in values.values) c.dispose();
+    for (final controller in values.values) {
+      controller.dispose();
+    }
     values.clear();
-    for (final f in next.fields)
-      values[f.id] = TextEditingController(text: f.initialValue);
+    for (final field in next.fields) {
+      values[field.id] = TextEditingController(text: field.initialValue);
+    }
   }
 
   Future<void> submit() async {
-    if (!key.currentState!.validate()) return;
+    if (!key.currentState!.validate()) {
+      return;
+    }
     final token = await storage.read(key: 'github_pat');
     if (token == null || token.isEmpty) {
-      if (mounted)
+      if (mounted) {
         await Navigator.push(
-            context, MaterialPageRoute(builder: (_) => const SettingsScreen()));
+          context,
+          MaterialPageRoute(builder: (_) => const SettingsScreen()),
+        );
+      }
       return;
     }
     setState(() => busy = true);
     try {
-      final map = values.map((k, v) => MapEntry(k, v.text));
+      final map = values.map((key, value) => MapEntry(key, value.text));
       final url = await GitHubService(token).createIssue(
-          title: '${template.titlePrefix}${title.text.trim()}',
-          body: GitHubService.issueBody(template, map));
+        title: '${template.titlePrefix}${title.text.trim()}',
+        body: GitHubService.issueBody(template, map),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Issue erstellt: $url')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Issue erstellt: $url')),
+        );
         title.clear();
-        for (final f in template.fields) values[f.id]!.text = f.initialValue;
+        for (final field in template.fields) {
+          values[field.id]!.text = field.initialValue;
+        }
         setState(() {});
       }
-    } catch (e) {
-      if (mounted)
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Fehler: $e')));
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Fehler: $error')),
+        );
+      }
     } finally {
-      if (mounted) setState(() => busy = false);
+      if (mounted) {
+        setState(() => busy = false);
+      }
     }
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-      appBar: AppBar(title: const Text('Wiki-Quelle erfassen'), actions: [
-        IconButton(
-            onPressed: () => Navigator.push(context,
-                MaterialPageRoute(builder: (_) => const SettingsScreen())),
-            icon: const Icon(Icons.settings))
-      ]),
+  void dispose() {
+    title.dispose();
+    for (final controller in values.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wiki-Quelle erfassen'),
+        actions: [
+          IconButton(
+            tooltip: 'Einstellungen öffnen',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+            ),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
       body: Form(
-          key: key,
-          child: ListView(padding: const EdgeInsets.all(16), children: [
+        key: key,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
             DropdownButtonFormField<SourceTemplate>(
-                value: template,
-                decoration: const InputDecoration(labelText: 'Quellentyp'),
-                items: sourceTemplates
-                    .map((t) => DropdownMenuItem(value: t, child: Text(t.name)))
-                    .toList(),
-                onChanged: (t) => setState(() => _select(t!))),
+              value: template,
+              decoration: const InputDecoration(labelText: 'Quellentyp'),
+              items: sourceTemplates
+                  .map(
+                    (item) => DropdownMenuItem(
+                      value: item,
+                      child: Text(item.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (selected) {
+                if (selected != null) {
+                  setState(() => _select(selected));
+                }
+              },
+            ),
             Padding(
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                child: Text(template.description)),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Text(template.description),
+            ),
             TextFormField(
-                controller: title,
-                decoration: InputDecoration(
-                    labelText: 'Issue-Titel', prefixText: template.titlePrefix),
-                validator: (v) =>
-                    (v ?? '').trim().isEmpty ? 'Pflichtfeld' : null),
+              controller: title,
+              decoration: InputDecoration(
+                labelText: 'Issue-Titel',
+                prefixText: template.titlePrefix,
+              ),
+              validator: (value) =>
+                  (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null,
+            ),
             const SizedBox(height: 12),
             ...template.fields.map(_field),
             const SizedBox(height: 20),
             FilledButton.icon(
-                onPressed: busy ? null : submit,
-                icon: const Icon(Icons.cloud_upload),
-                label: Text(busy
+              onPressed: busy ? null : submit,
+              icon: const Icon(Icons.cloud_upload),
+              label: Text(
+                busy
                     ? 'Wird erstellt …'
-                    : 'Issue mit Label „quelle“ erstellen')),
-          ])));
-  Widget _field(SourceField f) {
-    final c = values[f.id]!;
-    if (f.kind == FieldKind.dropdown)
+                    : 'Issue mit Label „quelle“ erstellen',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _field(SourceField field) {
+    final controller = values[field.id]!;
+    if (field.kind == FieldKind.dropdown) {
       return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: DropdownButtonFormField<String>(
-              value: c.text.isEmpty ? null : c.text,
-              decoration: InputDecoration(
-                  labelText: f.label, helperText: f.description),
-              items: f.options
-                  .map((o) => DropdownMenuItem(value: o, child: Text(o)))
-                  .toList(),
-              onChanged: (v) => c.text = v ?? '',
-              validator: (v) =>
-                  f.required && v == null ? 'Pflichtfeld' : null));
-    return Padding(
         padding: const EdgeInsets.only(bottom: 12),
-        child: TextFormField(
-            controller: c,
-            minLines: f.kind == FieldKind.textarea ? 3 : 1,
-            maxLines: f.kind == FieldKind.textarea ? 8 : 1,
-            decoration: InputDecoration(
-                labelText: f.label,
-                helperText: f.description,
-                hintText: f.placeholder,
-                alignLabelWithHint: true),
-            validator: (v) =>
-                f.required && (v ?? '').trim().isEmpty ? 'Pflichtfeld' : null));
+        child: DropdownButtonFormField<String>(
+          value: controller.text.isEmpty ? null : controller.text,
+          decoration: InputDecoration(
+            labelText: field.label,
+            helperText: field.description,
+          ),
+          items: field.options
+              .map(
+                (option) => DropdownMenuItem(
+                  value: option,
+                  child: Text(option),
+                ),
+              )
+              .toList(),
+          onChanged: (value) => controller.text = value ?? '',
+          validator: (value) =>
+              field.required && value == null ? 'Pflichtfeld' : null,
+        ),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: TextFormField(
+        controller: controller,
+        minLines: field.kind == FieldKind.textarea ? 3 : 1,
+        maxLines: field.kind == FieldKind.textarea ? 8 : 1,
+        decoration: InputDecoration(
+          labelText: field.label,
+          helperText: field.description,
+          hintText: field.placeholder,
+          alignLabelWithHint: true,
+        ),
+        validator: (value) => field.required && (value ?? '').trim().isEmpty
+            ? 'Pflichtfeld'
+            : null,
+      ),
+    );
   }
 }

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,32 @@
+import 'package:developer_wiki_source_capture/models/source_template.dart';
+import 'package:developer_wiki_source_capture/screens/home_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('home screen offers sources, import and settings', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: HomeScreen()),
+    );
+
+    expect(find.text('Neue Quelle erfassen'), findsOneWidget);
+    expect(find.text('Quellen ins Wiki importieren'), findsOneWidget);
+    expect(find.byIcon(Icons.settings), findsOneWidget);
+    for (final template in sourceTemplates) {
+      expect(find.text(template.name), findsOneWidget);
+    }
+  });
+
+  testWidgets('selected source opens matching form', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: HomeScreen()),
+    );
+
+    final template = sourceTemplates.first;
+    await tester.tap(find.text(template.name));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Wiki-Quelle erfassen'), findsOneWidget);
+    expect(find.text(template.description), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #18

## Umsetzung
- zentrale Startseite nach erfolgreicher Konfiguration
- sichtbare Quellenarten aus dem bestehenden `sourceTemplates`-Modell
- Auswahl einer Quellenart öffnet das vorhandene Erfassungsformular mit passender Vorauswahl
- Einstellungen bleiben direkt erreichbar
- Aktion `Quellen ins Wiki importieren` ist sichtbar; der eigentliche Dispatch folgt wie geplant in #21
- normale Zurück-Navigation aus Formular und Einstellungen führt zur Startseite zurück

## Architektur
Die Startseite verwendet das bestehende Quellenmodell und erzeugt keine zweite Quellenlogik. Das Erfassungsformular erhält lediglich eine initiale `SourceTemplate`-Auswahl und bleibt der zentrale Formularweg.

## Prüfungen
- Akzeptanzkriterien von #18 gegen die Implementierung geprüft
- Widget-Tests für sichtbare Hauptaktionen und Navigation in das gewählte Quellenformular ergänzt
- bestehende `curly_braces_in_flow_control_structures`-Stellen im im Rahmen der Story angepassten Formular bereinigt
- Branch-Diff gegen Story #17 geprüft

`dart format`, `flutter analyze` und `flutter test` können über den GitHub-Connector nicht lokal ausgeführt werden und sollten vor Merge lokal bzw. durch CI laufen.

## Abhängigkeit
Dieser PR ist absichtlich auf `story/17-wiki-configuration` gestapelt und sollte nach PR #27 gemergt werden. Danach kann die Basis auf `master` umgestellt werden, falls GitHub das nicht automatisch übernimmt.
