### PR TITLE
Create source issues in configured wiki

### DIFF
--- a/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
@@ -1,5 +1,35 @@
 package de.huluvu.developer_wiki_source_capture
 
+import android.content.Intent
+import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "developer_wiki/external_url"
+        ).setMethodCallHandler { call, result ->
+            if (call.method != "open") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+
+            val url = call.argument<String>("url")
+            if (url.isNullOrBlank()) {
+                result.error("invalid_url", "URL fehlt.", null)
+                return@setMethodCallHandler
+            }
+
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                result.success(null)
+            } catch (error: Exception) {
+                result.error("open_failed", error.message, null)
+            }
+        }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'models/wiki_configuration.dart';
+import 'screens/home_screen.dart';
 import 'screens/settings_screen.dart';
-import 'screens/source_form_screen.dart';
 import 'services/configuration_service.dart';
 
 void main() => runApp(const WikiSourceApp());
@@ -59,7 +59,7 @@ class _WikiSourceAppState extends State<WikiSourceApp> {
             );
           }
           if (snapshot.data?.isComplete == true) {
-            return const SourceFormScreen();
+            return const HomeScreen();
           }
           return SettingsScreen(
             isSetup: true,

--- a/lib/models/created_issue.dart
+++ b/lib/models/created_issue.dart
@@ -1,0 +1,9 @@
+class CreatedIssue {
+  const CreatedIssue({
+    required this.number,
+    required this.url,
+  });
+
+  final int number;
+  final String url;
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../models/source_template.dart';
+import 'settings_screen.dart';
+import 'source_form_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key, this.onImportRequested});
+
+  final VoidCallback? onImportRequested;
+
+  void _openSource(BuildContext context, SourceTemplate template) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SourceFormScreen(initialTemplate: template),
+      ),
+    );
+  }
+
+  void _openSettings(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SettingsScreen()),
+    );
+  }
+
+  void _requestImport(BuildContext context) {
+    if (onImportRequested != null) {
+      onImportRequested!();
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Der Wiki-Import wird in Story #21 umgesetzt.'),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Developer Wiki'),
+        actions: [
+          IconButton(
+            tooltip: 'Einstellungen öffnen',
+            onPressed: () => _openSettings(context),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Neue Quelle erfassen',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          const Text('Wähle die passende Quellenart aus.'),
+          const SizedBox(height: 16),
+          ...sourceTemplates.map(
+            (template) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Card(
+                child: ListTile(
+                  minVerticalPadding: 16,
+                  title: Text(template.name),
+                  subtitle: Text(template.description),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _openSource(context, template),
+                ),
+              ),
+            ),
+          ),
+          const Divider(height: 32),
+          FilledButton.tonalIcon(
+            onPressed: () => _requestImport(context),
+            icon: const Icon(Icons.sync),
+            label: const Text('Quellen ins Wiki importieren'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import '../models/source_template.dart';
 import '../services/github_service.dart';
 import 'settings_screen.dart';
 
 class SourceFormScreen extends StatefulWidget {
-  const SourceFormScreen({super.key});
+  const SourceFormScreen({
+    super.key,
+    this.initialTemplate,
+  });
+
+  final SourceTemplate? initialTemplate;
+
   @override
   State<SourceFormScreen> createState() => _SourceFormScreenState();
 }
@@ -14,119 +21,192 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   final key = GlobalKey<FormState>();
   final title = TextEditingController();
   final storage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true));
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
+
   @override
   void initState() {
     super.initState();
-    _select(sourceTemplates.first);
+    _select(widget.initialTemplate ?? sourceTemplates.first);
   }
 
   void _select(SourceTemplate next) {
     template = next;
-    for (final c in values.values) c.dispose();
+    for (final controller in values.values) {
+      controller.dispose();
+    }
     values.clear();
-    for (final f in next.fields)
-      values[f.id] = TextEditingController(text: f.initialValue);
+    for (final field in next.fields) {
+      values[field.id] = TextEditingController(text: field.initialValue);
+    }
   }
 
   Future<void> submit() async {
-    if (!key.currentState!.validate()) return;
+    if (!key.currentState!.validate()) {
+      return;
+    }
     final token = await storage.read(key: 'github_pat');
     if (token == null || token.isEmpty) {
-      if (mounted)
+      if (mounted) {
         await Navigator.push(
-            context, MaterialPageRoute(builder: (_) => const SettingsScreen()));
+          context,
+          MaterialPageRoute(builder: (_) => const SettingsScreen()),
+        );
+      }
       return;
     }
     setState(() => busy = true);
     try {
-      final map = values.map((k, v) => MapEntry(k, v.text));
+      final map = values.map((key, value) => MapEntry(key, value.text));
       final url = await GitHubService(token).createIssue(
-          title: '${template.titlePrefix}${title.text.trim()}',
-          body: GitHubService.issueBody(template, map));
+        title: '${template.titlePrefix}${title.text.trim()}',
+        body: GitHubService.issueBody(template, map),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Issue erstellt: $url')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Issue erstellt: $url')),
+        );
         title.clear();
-        for (final f in template.fields) values[f.id]!.text = f.initialValue;
+        for (final field in template.fields) {
+          values[field.id]!.text = field.initialValue;
+        }
         setState(() {});
       }
-    } catch (e) {
-      if (mounted)
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Fehler: $e')));
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Fehler: $error')),
+        );
+      }
     } finally {
-      if (mounted) setState(() => busy = false);
+      if (mounted) {
+        setState(() => busy = false);
+      }
     }
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-      appBar: AppBar(title: const Text('Wiki-Quelle erfassen'), actions: [
-        IconButton(
-            onPressed: () => Navigator.push(context,
-                MaterialPageRoute(builder: (_) => const SettingsScreen())),
-            icon: const Icon(Icons.settings))
-      ]),
+  void dispose() {
+    title.dispose();
+    for (final controller in values.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wiki-Quelle erfassen'),
+        actions: [
+          IconButton(
+            tooltip: 'Einstellungen öffnen',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+            ),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
       body: Form(
-          key: key,
-          child: ListView(padding: const EdgeInsets.all(16), children: [
+        key: key,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
             DropdownButtonFormField<SourceTemplate>(
-                value: template,
-                decoration: const InputDecoration(labelText: 'Quellentyp'),
-                items: sourceTemplates
-                    .map((t) => DropdownMenuItem(value: t, child: Text(t.name)))
-                    .toList(),
-                onChanged: (t) => setState(() => _select(t!))),
+              value: template,
+              decoration: const InputDecoration(labelText: 'Quellentyp'),
+              items: sourceTemplates
+                  .map(
+                    (item) => DropdownMenuItem(
+                      value: item,
+                      child: Text(item.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (selected) {
+                if (selected != null) {
+                  setState(() => _select(selected));
+                }
+              },
+            ),
             Padding(
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                child: Text(template.description)),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Text(template.description),
+            ),
             TextFormField(
-                controller: title,
-                decoration: InputDecoration(
-                    labelText: 'Issue-Titel', prefixText: template.titlePrefix),
-                validator: (v) =>
-                    (v ?? '').trim().isEmpty ? 'Pflichtfeld' : null),
+              controller: title,
+              decoration: InputDecoration(
+                labelText: 'Issue-Titel',
+                prefixText: template.titlePrefix,
+              ),
+              validator: (value) =>
+                  (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null,
+            ),
             const SizedBox(height: 12),
             ...template.fields.map(_field),
             const SizedBox(height: 20),
             FilledButton.icon(
-                onPressed: busy ? null : submit,
-                icon: const Icon(Icons.cloud_upload),
-                label: Text(busy
+              onPressed: busy ? null : submit,
+              icon: const Icon(Icons.cloud_upload),
+              label: Text(
+                busy
                     ? 'Wird erstellt …'
-                    : 'Issue mit Label „quelle“ erstellen')),
-          ])));
-  Widget _field(SourceField f) {
-    final c = values[f.id]!;
-    if (f.kind == FieldKind.dropdown)
+                    : 'Issue mit Label „quelle“ erstellen',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _field(SourceField field) {
+    final controller = values[field.id]!;
+    if (field.kind == FieldKind.dropdown) {
       return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: DropdownButtonFormField<String>(
-              value: c.text.isEmpty ? null : c.text,
-              decoration: InputDecoration(
-                  labelText: f.label, helperText: f.description),
-              items: f.options
-                  .map((o) => DropdownMenuItem(value: o, child: Text(o)))
-                  .toList(),
-              onChanged: (v) => c.text = v ?? '',
-              validator: (v) =>
-                  f.required && v == null ? 'Pflichtfeld' : null));
-    return Padding(
         padding: const EdgeInsets.only(bottom: 12),
-        child: TextFormField(
-            controller: c,
-            minLines: f.kind == FieldKind.textarea ? 3 : 1,
-            maxLines: f.kind == FieldKind.textarea ? 8 : 1,
-            decoration: InputDecoration(
-                labelText: f.label,
-                helperText: f.description,
-                hintText: f.placeholder,
-                alignLabelWithHint: true),
-            validator: (v) =>
-                f.required && (v ?? '').trim().isEmpty ? 'Pflichtfeld' : null));
+        child: DropdownButtonFormField<String>(
+          value: controller.text.isEmpty ? null : controller.text,
+          decoration: InputDecoration(
+            labelText: field.label,
+            helperText: field.description,
+          ),
+          items: field.options
+              .map(
+                (option) => DropdownMenuItem(
+                  value: option,
+                  child: Text(option),
+                ),
+              )
+              .toList(),
+          onChanged: (value) => controller.text = value ?? '',
+          validator: (value) =>
+              field.required && value == null ? 'Pflichtfeld' : null,
+        ),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: TextFormField(
+        controller: controller,
+        minLines: field.kind == FieldKind.textarea ? 3 : 1,
+        maxLines: field.kind == FieldKind.textarea ? 8 : 1,
+        decoration: InputDecoration(
+          labelText: field.label,
+          helperText: field.description,
+          hintText: field.placeholder,
+          alignLabelWithHint: true,
+        ),
+        validator: (value) => field.required && (value ?? '').trim().isEmpty
+            ? 'Pflichtfeld'
+            : null,
+      ),
+    );
   }
 }

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+import '../models/created_issue.dart';
 import '../models/source_template.dart';
+import '../models/wiki_configuration.dart';
+import '../services/configuration_service.dart';
+import '../services/external_url_service.dart';
 import '../services/github_service.dart';
 import 'settings_screen.dart';
 
@@ -20,12 +23,13 @@ class SourceFormScreen extends StatefulWidget {
 class _SourceFormScreenState extends State<SourceFormScreen> {
   final key = GlobalKey<FormState>();
   final title = TextEditingController();
-  final storage = const FlutterSecureStorage(
-    aOptions: AndroidOptions(encryptedSharedPreferences: true),
-  );
+  final _configurationService = ConfigurationService();
+  final _externalUrlService = ExternalUrlService();
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
+  CreatedIssue? _createdIssue;
+  String? _errorMessage;
 
   @override
   void initState() {
@@ -42,50 +46,79 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     for (final field in next.fields) {
       values[field.id] = TextEditingController(text: field.initialValue);
     }
+    _createdIssue = null;
+    _errorMessage = null;
   }
 
   Future<void> submit() async {
     if (!key.currentState!.validate()) {
       return;
     }
-    final token = await storage.read(key: 'github_pat');
-    if (token == null || token.isEmpty) {
-      if (mounted) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const SettingsScreen()),
-        );
-      }
-      return;
-    }
-    setState(() => busy = true);
+
+    setState(() {
+      busy = true;
+      _errorMessage = null;
+    });
     try {
+      final configuration = await _configurationService.load();
+      final repository = _repositoryFrom(configuration);
       final map = values.map((key, value) => MapEntry(key, value.text));
-      final url = await GitHubService(token).createIssue(
+      final issue = await GitHubService(
+        configuration.token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).createIssue(
         title: '${template.titlePrefix}${title.text.trim()}',
         body: GitHubService.issueBody(template, map),
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Issue erstellt: $url')),
-        );
-        title.clear();
-        for (final field in template.fields) {
-          values[field.id]!.text = field.initialValue;
-        }
-        setState(() {});
+        setState(() => _createdIssue = issue);
       }
     } catch (error) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Fehler: $error')),
-        );
+        setState(() {
+          _errorMessage = 'Quelle konnte nicht erstellt werden: $error';
+        });
       }
     } finally {
       if (mounted) {
         setState(() => busy = false);
       }
     }
+  }
+
+  GitHubRepository _repositoryFrom(WikiConfiguration configuration) {
+    if (!configuration.isComplete) {
+      throw const FormatException(
+        'Wiki-Konfiguration ist unvollständig. Einstellungen prüfen.',
+      );
+    }
+    return GitHubRepository.parse(configuration.repositoryUrl);
+  }
+
+  Future<void> _openCreatedIssue() async {
+    final issue = _createdIssue;
+    if (issue == null) {
+      return;
+    }
+    try {
+      await _externalUrlService.open(issue.url);
+    } catch (error) {
+      if (mounted) {
+        setState(() => _errorMessage = 'Issue konnte nicht geöffnet werden: $error');
+      }
+    }
+  }
+
+  void _startNewSource() {
+    title.clear();
+    for (final field in template.fields) {
+      values[field.id]!.text = field.initialValue;
+    }
+    setState(() {
+      _createdIssue = null;
+      _errorMessage = null;
+    });
   }
 
   @override
@@ -129,18 +162,23 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                     ),
                   )
                   .toList(),
-              onChanged: (selected) {
-                if (selected != null) {
-                  setState(() => _select(selected));
-                }
-              },
+              onChanged: busy
+                  ? null
+                  : (selected) {
+                      if (selected != null) {
+                        setState(() => _select(selected));
+                      }
+                    },
             ),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 12),
               child: Text(template.description),
             ),
+            if (_createdIssue != null) _successCard(_createdIssue!),
+            if (_errorMessage != null) _errorCard(_errorMessage!),
             TextFormField(
               controller: title,
+              enabled: !busy,
               decoration: InputDecoration(
                 labelText: 'Issue-Titel',
                 prefixText: template.titlePrefix,
@@ -154,13 +192,60 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             FilledButton.icon(
               onPressed: busy ? null : submit,
               icon: const Icon(Icons.cloud_upload),
-              label: Text(
-                busy
-                    ? 'Wird erstellt …'
-                    : 'Issue mit Label „quelle“ erstellen',
-              ),
+              label: Text(busy ? 'Wird erstellt …' : 'Quelle speichern'),
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _successCard(CreatedIssue issue) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Quelle erstellt – Issue #${issue.number}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: _openCreatedIssue,
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('Issue öffnen'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: _startNewSource,
+                  icon: const Icon(Icons.add),
+                  label: const Text('Neue Quelle'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _errorCard(String message) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Semantics(
+          liveRegion: true,
+          child: Text(
+            message,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
         ),
       ),
     );
@@ -185,7 +270,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                 ),
               )
               .toList(),
-          onChanged: (value) => controller.text = value ?? '',
+          onChanged: busy ? null : (value) => controller.text = value ?? '',
           validator: (value) =>
               field.required && value == null ? 'Pflichtfeld' : null,
         ),
@@ -195,6 +280,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       padding: const EdgeInsets.only(bottom: 12),
       child: TextFormField(
         controller: controller,
+        enabled: !busy,
         minLines: field.kind == FieldKind.textarea ? 3 : 1,
         maxLines: field.kind == FieldKind.textarea ? 8 : 1,
         decoration: InputDecoration(

--- a/lib/services/external_url_service.dart
+++ b/lib/services/external_url_service.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/services.dart';
+
+class ExternalUrlService {
+  static const _channel = MethodChannel('developer_wiki/external_url');
+
+  Future<void> open(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) {
+      throw const FormatException('Ungültiger Link.');
+    }
+    await _channel.invokeMethod<void>('open', {'url': url});
+  }
+}

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../models/created_issue.dart';
 import '../models/source_template.dart';
 
 class GitHubService {
@@ -21,7 +22,7 @@ class GitHubService {
         'X-GitHub-Api-Version': '2022-11-28',
       };
 
-  Future<String> createIssue({
+  Future<CreatedIssue> createIssue({
     required String title,
     required String body,
   }) async {
@@ -37,8 +38,11 @@ class GitHubService {
     if (response.statusCode != 201) {
       throw Exception(_message(response));
     }
-    return (jsonDecode(response.body) as Map<String, dynamic>)['html_url']
-        as String;
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return CreatedIssue(
+      number: data['number'] as int,
+      url: data['html_url'] as String,
+    );
   }
 
   Future<String> login() async {

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -10,11 +10,13 @@ class GitHubService {
     this.token, {
     this.owner = 'Huluvu424242',
     this.repo = 'Developer-Wiki',
-  });
+    http.Client? client,
+  }) : _client = client ?? http.Client();
 
   final String token;
   final String owner;
   final String repo;
+  final http.Client _client;
 
   Map<String, String> get _headers => {
         'Accept': 'application/vnd.github+json',
@@ -26,7 +28,7 @@ class GitHubService {
     required String title,
     required String body,
   }) async {
-    final response = await http.post(
+    final response = await _client.post(
       Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
       headers: {..._headers, 'Content-Type': 'application/json'},
       body: jsonEncode({
@@ -46,7 +48,7 @@ class GitHubService {
   }
 
   Future<String> login() async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('https://api.github.com/user'),
       headers: _headers,
     );
@@ -59,7 +61,7 @@ class GitHubService {
 
   Future<String> verifyRepositoryAccess() async {
     final loginName = await login();
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('https://api.github.com/repos/$owner/$repo'),
       headers: _headers,
     );

--- a/test/github_service_test.dart
+++ b/test/github_service_test.dart
@@ -1,12 +1,53 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'dart:convert';
+
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/services/github_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 void main() {
   test('Issue-Body entspricht GitHub-Issue-Form-Struktur', () {
-    final body = GitHubService.issueBody(sourceTemplates.first,
-        {'source_title': 'Test', 'urls': 'https://example.org'});
-    expect(body,
-        '### Titel der Quelle\n\nTest\n\n### Link oder zusammengehörige Links\n\nhttps://example.org');
+    final body = GitHubService.issueBody(
+      sourceTemplates.first,
+      {'source_title': 'Test', 'urls': 'https://example.org'},
+    );
+    expect(
+      body,
+      '### Titel der Quelle\n\nTest\n\n### Link oder zusammengehörige Links\n\nhttps://example.org',
+    );
+  });
+
+  test('createIssue uses configured repository and source label', () async {
+    late http.Request capturedRequest;
+    final client = MockClient((request) async {
+      capturedRequest = request;
+      return http.Response(
+        jsonEncode({
+          'number': 123,
+          'html_url': 'https://github.com/example/wiki/issues/123',
+        }),
+        201,
+      );
+    });
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: client,
+    );
+
+    final issue = await service.createIssue(title: 'Title', body: 'Body');
+
+    expect(
+      capturedRequest.url.toString(),
+      'https://api.github.com/repos/example/wiki/issues',
+    );
+    final payload = jsonDecode(capturedRequest.body) as Map<String, dynamic>;
+    expect(payload['title'], 'Title');
+    expect(payload['body'], 'Body');
+    expect(payload['labels'], ['quelle']);
+    expect(issue.number, 123);
+    expect(issue.url, 'https://github.com/example/wiki/issues/123');
   });
 }

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,32 @@
+import 'package:developer_wiki_source_capture/models/source_template.dart';
+import 'package:developer_wiki_source_capture/screens/home_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('home screen offers sources, import and settings', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: HomeScreen()),
+    );
+
+    expect(find.text('Neue Quelle erfassen'), findsOneWidget);
+    expect(find.text('Quellen ins Wiki importieren'), findsOneWidget);
+    expect(find.byIcon(Icons.settings), findsOneWidget);
+    for (final template in sourceTemplates) {
+      expect(find.text(template.name), findsOneWidget);
+    }
+  });
+
+  testWidgets('selected source opens matching form', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: HomeScreen()),
+    );
+
+    final template = sourceTemplates.first;
+    await tester.tap(find.text(template.name));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Wiki-Quelle erfassen'), findsOneWidget);
+    expect(find.text(template.description), findsOneWidget);
+  });
+}

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -10,11 +10,27 @@ void main() {
     );
 
     expect(find.text('Neue Quelle erfassen'), findsOneWidget);
-    expect(find.text('Quellen ins Wiki importieren'), findsOneWidget);
     expect(find.byIcon(Icons.settings), findsOneWidget);
+
+    final scrollable = find.byType(Scrollable);
+
     for (final template in sourceTemplates) {
+      await tester.scrollUntilVisible(
+        find.text(template.name),
+        200,
+        scrollable: scrollable,
+      );
+
       expect(find.text(template.name), findsOneWidget);
     }
+
+    await tester.scrollUntilVisible(
+      find.text('Quellen ins Wiki importieren'),
+      200,
+      scrollable: scrollable,
+    );
+
+    expect(find.text('Quellen ins Wiki importieren'), findsOneWidget);
   });
 
   testWidgets('selected source opens matching form', (tester) async {


### PR DESCRIPTION
Closes #19

## Umsetzung
- Quellenformular verwendet Repository und PAT aus der zentralen Konfiguration
- GitHub-Issue wird mit `quelle`-Label im konfigurierten Wiki erzeugt
- GitHub-Service liefert Issue-Nummer und URL als strukturiertes Ergebnis
- Erfolgszustand zeigt Issue-Nummer sowie Aktionen `Issue öffnen` und `Neue Quelle`
- API-Fehler werden im Formular angezeigt; bestehende Eingaben bleiben erhalten
- Öffnen des GitHub-Issues ist über eine klar isolierte Android-Plattformintegration gekapselt
- laufende Requests sperren Formularaktionen gegen Mehrfachauslösung

## Architektur
GitHub-API-Details bleiben im `GitHubService`, Konfiguration in `ConfigurationService`, das Ergebnis in `CreatedIssue` und die Android-spezifische URL-Öffnung in `ExternalUrlService`/`MainActivity`. Das Formular orchestriert nur den fachlichen Ablauf.

## Prüfungen
- Akzeptanzkriterien von #19 gegen die Implementierung geprüft
- bestehender Issue-Body-Test erhalten
- neuer Test prüft konfiguriertes Ziel-Repository, Payload, Label `quelle` sowie Rückgabe von Issue-Nummer/URL
- GitHub-Service erhält einen injizierbaren HTTP-Client für isolierte Tests
- Branch-Diff gegen Story #18 geprüft

`dart format`, `flutter analyze` und `flutter test` können über den verbundenen GitHub-Connector nicht lokal ausgeführt werden und sollten vor dem Merge lokal bzw. durch CI laufen.

## Abhängigkeit / offene Punkte
Dieser PR ist auf `story/18-home-source-selection` gestapelt und sollte nach PR #28 gemergt werden. Die URL-Öffnung ist für den primären Android-Zielpfad umgesetzt; weitere Plattformen können später eine eigene Adapter-Implementierung erhalten.
