### PR TITLE
Show recently captured source issues

### DIFF
--- a/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
@@ -1,5 +1,35 @@
 package de.huluvu.developer_wiki_source_capture
 
+import android.content.Intent
+import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "developer_wiki/external_url"
+        ).setMethodCallHandler { call, result ->
+            if (call.method != "open") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+
+            val url = call.argument<String>("url")
+            if (url.isNullOrBlank()) {
+                result.error("invalid_url", "URL fehlt.", null)
+                return@setMethodCallHandler
+            }
+
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                result.success(null)
+            } catch (error: Exception) {
+                result.error("open_failed", error.message, null)
+            }
+        }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'models/wiki_configuration.dart';
+import 'screens/home_screen.dart';
 import 'screens/settings_screen.dart';
-import 'screens/source_form_screen.dart';
 import 'services/configuration_service.dart';
 
 void main() => runApp(const WikiSourceApp());
@@ -59,7 +59,7 @@ class _WikiSourceAppState extends State<WikiSourceApp> {
             );
           }
           if (snapshot.data?.isComplete == true) {
-            return const SourceFormScreen();
+            return const HomeScreen();
           }
           return SettingsScreen(
             isSetup: true,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,72 @@
 import 'package:flutter/material.dart';
+
+import 'models/wiki_configuration.dart';
+import 'screens/settings_screen.dart';
 import 'screens/source_form_screen.dart';
+import 'services/configuration_service.dart';
 
 void main() => runApp(const WikiSourceApp());
 
-class WikiSourceApp extends StatelessWidget {
+class WikiSourceApp extends StatefulWidget {
   const WikiSourceApp({super.key});
+
   @override
-  Widget build(BuildContext context) => MaterialApp(
+  State<WikiSourceApp> createState() => _WikiSourceAppState();
+}
+
+class _WikiSourceAppState extends State<WikiSourceApp> {
+  final _configurationService = ConfigurationService();
+  late Future<WikiConfiguration> _configuration;
+
+  @override
+  void initState() {
+    super.initState();
+    _reloadConfiguration();
+  }
+
+  void _reloadConfiguration() {
+    _configuration = _configurationService.load();
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Developer Wiki Quellen',
       theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
-      home: const SourceFormScreen());
+      home: FutureBuilder<WikiConfiguration>(
+        future: _configuration,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (snapshot.hasError) {
+            return Scaffold(
+              body: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(
+                    'Konfiguration konnte nicht geladen werden: ${snapshot.error}',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            );
+          }
+          if (snapshot.data?.isComplete == true) {
+            return const SourceFormScreen();
+          }
+          return SettingsScreen(
+            isSetup: true,
+            onConfigured: _reloadConfiguration,
+          );
+        },
+      ),
+    );
+  }
 }

--- a/lib/models/created_issue.dart
+++ b/lib/models/created_issue.dart
@@ -1,0 +1,9 @@
+class CreatedIssue {
+  const CreatedIssue({
+    required this.number,
+    required this.url,
+  });
+
+  final int number;
+  final String url;
+}

--- a/lib/models/source_issue_summary.dart
+++ b/lib/models/source_issue_summary.dart
@@ -1,0 +1,13 @@
+class SourceIssueSummary {
+  const SourceIssueSummary({
+    required this.number,
+    required this.title,
+    required this.isOpen,
+    required this.url,
+  });
+
+  final int number;
+  final String title;
+  final bool isOpen;
+  final String url;
+}

--- a/lib/models/wiki_configuration.dart
+++ b/lib/models/wiki_configuration.dart
@@ -1,0 +1,48 @@
+class WikiConfiguration {
+  const WikiConfiguration({
+    required this.repositoryUrl,
+    required this.token,
+  });
+
+  static const defaultRepositoryUrl =
+      'https://github.com/Huluvu424242/Developer-Wiki';
+
+  final String repositoryUrl;
+  final String token;
+
+  bool get isComplete =>
+      repositoryUrl.trim().isNotEmpty && token.trim().isNotEmpty;
+}
+
+class GitHubRepository {
+  const GitHubRepository({required this.owner, required this.name});
+
+  final String owner;
+  final String name;
+
+  static GitHubRepository parse(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      throw const FormatException('Repository-Angabe fehlt.');
+    }
+
+    final normalized = trimmed.startsWith('http://') ||
+            trimmed.startsWith('https://')
+        ? trimmed
+        : 'https://github.com/$trimmed';
+    final uri = Uri.tryParse(normalized);
+    if (uri == null || uri.host.toLowerCase() != 'github.com') {
+      throw const FormatException('Bitte ein GitHub-Repository angeben.');
+    }
+
+    final segments = uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
+    if (segments.length != 2) {
+      throw const FormatException(
+          'Repository als https://github.com/owner/repo oder owner/repo angeben.');
+    }
+
+    return GitHubRepository(owner: segments[0], name: segments[1]);
+  }
+
+  String get url => 'https://github.com/$owner/$name';
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/source_template.dart';
+import 'recent_sources_screen.dart';
 import 'settings_screen.dart';
 import 'source_form_screen.dart';
 
@@ -15,6 +16,13 @@ class HomeScreen extends StatelessWidget {
       MaterialPageRoute(
         builder: (_) => SourceFormScreen(initialTemplate: template),
       ),
+    );
+  }
+
+  void _openRecentSources(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const RecentSourcesScreen()),
     );
   }
 
@@ -75,6 +83,12 @@ class HomeScreen extends StatelessWidget {
             ),
           ),
           const Divider(height: 32),
+          OutlinedButton.icon(
+            onPressed: () => _openRecentSources(context),
+            icon: const Icon(Icons.history),
+            label: const Text('Letzte Quellen'),
+          ),
+          const SizedBox(height: 12),
           FilledButton.tonalIcon(
             onPressed: () => _requestImport(context),
             icon: const Icon(Icons.sync),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../models/source_template.dart';
+import 'settings_screen.dart';
+import 'source_form_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key, this.onImportRequested});
+
+  final VoidCallback? onImportRequested;
+
+  void _openSource(BuildContext context, SourceTemplate template) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SourceFormScreen(initialTemplate: template),
+      ),
+    );
+  }
+
+  void _openSettings(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SettingsScreen()),
+    );
+  }
+
+  void _requestImport(BuildContext context) {
+    if (onImportRequested != null) {
+      onImportRequested!();
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Der Wiki-Import wird in Story #21 umgesetzt.'),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Developer Wiki'),
+        actions: [
+          IconButton(
+            tooltip: 'Einstellungen öffnen',
+            onPressed: () => _openSettings(context),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Neue Quelle erfassen',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          const Text('Wähle die passende Quellenart aus.'),
+          const SizedBox(height: 16),
+          ...sourceTemplates.map(
+            (template) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Card(
+                child: ListTile(
+                  minVerticalPadding: 16,
+                  title: Text(template.name),
+                  subtitle: Text(template.description),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _openSource(context, template),
+                ),
+              ),
+            ),
+          ),
+          const Divider(height: 32),
+          FilledButton.tonalIcon(
+            onPressed: () => _requestImport(context),
+            icon: const Icon(Icons.sync),
+            label: const Text('Quellen ins Wiki importieren'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/recent_sources_screen.dart
+++ b/lib/screens/recent_sources_screen.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+
+import '../models/source_issue_summary.dart';
+import '../models/wiki_configuration.dart';
+import '../services/configuration_service.dart';
+import '../services/external_url_service.dart';
+import '../services/github_service.dart';
+import 'source_form_screen.dart';
+
+class RecentSourcesScreen extends StatefulWidget {
+  const RecentSourcesScreen({super.key});
+
+  @override
+  State<RecentSourcesScreen> createState() => _RecentSourcesScreenState();
+}
+
+class _RecentSourcesScreenState extends State<RecentSourcesScreen> {
+  final _configurationService = ConfigurationService();
+  final _externalUrlService = ExternalUrlService();
+
+  bool _busy = false;
+  String? _errorMessage;
+  List<SourceIssueSummary> _issues = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _busy = true;
+      _errorMessage = null;
+    });
+    try {
+      final configuration = await _configurationService.load();
+      final repository = _repositoryFrom(configuration);
+      final issues = await GitHubService(
+        configuration.token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).listRecentSourceIssues();
+      if (mounted) {
+        setState(() => _issues = issues);
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'Quellen konnten nicht geladen werden: $error';
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  GitHubRepository _repositoryFrom(WikiConfiguration configuration) {
+    if (!configuration.isComplete) {
+      throw const FormatException(
+        'Wiki-Konfiguration ist unvollständig. Einstellungen prüfen.',
+      );
+    }
+    return GitHubRepository.parse(configuration.repositoryUrl);
+  }
+
+  Future<void> _openIssue(SourceIssueSummary issue) async {
+    try {
+      await _externalUrlService.open(issue.url);
+    } catch (error) {
+      if (mounted) {
+        setState(() => _errorMessage = 'Issue konnte nicht geöffnet werden: $error');
+      }
+    }
+  }
+
+  void _captureSource() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SourceFormScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Letzte Quellen'),
+        actions: [
+          IconButton(
+            tooltip: 'Quellen aktualisieren',
+            onPressed: _busy ? null : _load,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: _body(),
+    );
+  }
+
+  Widget _body() {
+    if (_busy && _issues.isEmpty && _errorMessage == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_errorMessage != null && _issues.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Semantics(
+                liveRegion: true,
+                child: Text(
+                  _errorMessage!,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+              const SizedBox(height: 16),
+              FilledButton.tonalIcon(
+                onPressed: _load,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Erneut versuchen'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_issues.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Noch keine Quellen gefunden.'),
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: _captureSource,
+                icon: const Icon(Icons.add),
+                label: const Text('Quelle erfassen'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _issues.length + (_errorMessage == null ? 0 : 1),
+        itemBuilder: (context, index) {
+          if (index == 0 && _errorMessage != null) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Semantics(
+                liveRegion: true,
+                child: Text(
+                  _errorMessage!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+            );
+          }
+          final issueIndex = index - (_errorMessage == null ? 0 : 1);
+          final issue = _issues[issueIndex];
+          return Card(
+            child: ListTile(
+              minVerticalPadding: 14,
+              title: Text('#${issue.number} ${issue.title}'),
+              subtitle: Text(issue.isOpen ? 'offen' : 'geschlossen'),
+              trailing: const Icon(Icons.open_in_new),
+              onTap: () => _openIssue(issue),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,68 +1,236 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/wiki_configuration.dart';
+import '../services/configuration_service.dart';
 import '../services/github_service.dart';
 
 class SettingsScreen extends StatefulWidget {
-  const SettingsScreen({super.key});
+  const SettingsScreen({
+    super.key,
+    this.isSetup = false,
+    this.onConfigured,
+  });
+
+  final bool isSetup;
+  final VoidCallback? onConfigured;
+
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  final storage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true));
-  final controller = TextEditingController();
-  bool busy = false, obscure = true;
+  final _repositoryController = TextEditingController();
+  final _tokenController = TextEditingController();
+  final _configurationService = ConfigurationService();
+
+  bool _busy = false;
+  bool _obscure = true;
+  bool _connectionVerified = false;
+  String? _status;
+  bool _statusIsError = false;
+
   @override
   void initState() {
     super.initState();
-    storage.read(key: 'github_pat').then((v) {
-      if (mounted) controller.text = v ?? '';
+    _repositoryController.addListener(_invalidateVerification);
+    _tokenController.addListener(_invalidateVerification);
+    _load();
+  }
+
+  Future<void> _load() async {
+    final configuration = await _configurationService.load();
+    if (!mounted) {
+      return;
+    }
+    _repositoryController.text = configuration.repositoryUrl;
+    _tokenController.text = configuration.token;
+  }
+
+  void _invalidateVerification() {
+    if (!_connectionVerified && _status == null) {
+      return;
+    }
+    setState(() {
+      _connectionVerified = false;
+      _status = null;
+      _statusIsError = false;
     });
   }
 
-  Future<void> save() async {
-    setState(() => busy = true);
+  Future<void> _testConnection() async {
+    final token = _tokenController.text.trim();
+    if (token.isEmpty) {
+      _setStatus('Bitte zuerst ein Fine-grained PAT eingeben.', isError: true);
+      return;
+    }
+
+    GitHubRepository repository;
     try {
-      final token = controller.text.trim();
-      final login = await GitHubService(token).login();
-      await storage.write(key: 'github_pat', value: token);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Gespeichert – verbunden als $login')));
-        Navigator.pop(context, true);
+      repository = GitHubRepository.parse(_repositoryController.text);
+    } on FormatException catch (error) {
+      _setStatus(error.message.toString(), isError: true);
+      return;
+    }
+
+    setState(() {
+      _busy = true;
+      _status = 'Verbindung wird geprüft …';
+      _statusIsError = false;
+      _connectionVerified = false;
+    });
+
+    try {
+      final login = await GitHubService(
+        token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).verifyRepositoryAccess();
+      if (!mounted) {
+        return;
       }
-    } catch (e) {
-      if (mounted)
-        ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Verbindung fehlgeschlagen: $e')));
+      setState(() {
+        _connectionVerified = true;
+        _status = 'Verbindung erfolgreich – angemeldet als $login.';
+        _statusIsError = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _setStatus(
+        'Zugriff fehlgeschlagen. Token, Repository und Berechtigungen prüfen: '
+        '$error',
+        isError: true,
+      );
     } finally {
-      if (mounted) setState(() => busy = false);
+      if (mounted) {
+        setState(() => _busy = false);
+      }
     }
   }
 
+  Future<void> _save() async {
+    if (!_connectionVerified) {
+      _setStatus('Bitte die Verbindung vor dem Speichern erfolgreich testen.',
+          isError: true);
+      return;
+    }
+
+    final repository = GitHubRepository.parse(_repositoryController.text);
+    setState(() => _busy = true);
+    try {
+      await _configurationService.save(
+        WikiConfiguration(
+          repositoryUrl: repository.url,
+          token: _tokenController.text.trim(),
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      widget.onConfigured?.call();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Wiki-Verbindung gespeichert.')),
+      );
+      if (!widget.isSetup && Navigator.canPop(context)) {
+        Navigator.pop(context, true);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  void _setStatus(String message, {required bool isError}) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _status = message;
+      _statusIsError = isError;
+      if (isError) {
+        _connectionVerified = false;
+      }
+    });
+  }
+
   @override
-  Widget build(BuildContext context) => Scaffold(
-      appBar: AppBar(title: const Text('Einstellungen')),
-      body: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(children: [
-            TextField(
-                controller: controller,
-                obscureText: obscure,
-                decoration: InputDecoration(
-                    labelText: 'GitHub Fine-grained PAT',
-                    helperText:
-                        'Benötigt Issues: Read and write für Developer-Wiki.',
-                    suffixIcon: IconButton(
-                        onPressed: () => setState(() => obscure = !obscure),
-                        icon: Icon(obscure
-                            ? Icons.visibility
-                            : Icons.visibility_off)))),
+  void dispose() {
+    _repositoryController
+      ..removeListener(_invalidateVerification)
+      ..dispose();
+    _tokenController
+      ..removeListener(_invalidateVerification)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: !widget.isSetup,
+        title: Text(widget.isSetup ? 'Developer Wiki – Einrichtung' : 'Einstellungen'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          TextField(
+            controller: _repositoryController,
+            enabled: !_busy,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              labelText: 'GitHub Wiki',
+              helperText: 'Repository-URL oder owner/repo',
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _tokenController,
+            enabled: !_busy,
+            obscureText: _obscure,
+            enableSuggestions: false,
+            autocorrect: false,
+            decoration: InputDecoration(
+              labelText: 'Fine-grained PAT',
+              helperText: 'Das Token wird nur im geschützten lokalen Speicher abgelegt.',
+              suffixIcon: IconButton(
+                tooltip: _obscure ? 'Token anzeigen' : 'Token ausblenden',
+                onPressed: _busy ? null : () => setState(() => _obscure = !_obscure),
+                icon: Icon(_obscure ? Icons.visibility : Icons.visibility_off),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          FilledButton.tonalIcon(
+            onPressed: _busy ? null : _testConnection,
+            icon: const Icon(Icons.link),
+            label: const Text('Verbindung testen'),
+          ),
+          if (_status != null) ...[
             const SizedBox(height: 16),
-            FilledButton.icon(
-                onPressed: busy ? null : save,
-                icon: const Icon(Icons.lock),
-                label: Text(busy ? 'Prüfe …' : 'Prüfen und sicher speichern')),
-          ])));
+            Semantics(
+              liveRegion: true,
+              child: Text(
+                _status!,
+                style: TextStyle(
+                  color: _statusIsError
+                      ? Theme.of(context).colorScheme.error
+                      : null,
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 20),
+          FilledButton.icon(
+            onPressed: _busy || !_connectionVerified ? null : _save,
+            icon: const Icon(Icons.save),
+            label: const Text('Speichern'),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import '../models/source_template.dart';
 import '../services/github_service.dart';
 import 'settings_screen.dart';
 
 class SourceFormScreen extends StatefulWidget {
-  const SourceFormScreen({super.key});
+  const SourceFormScreen({
+    super.key,
+    this.initialTemplate,
+  });
+
+  final SourceTemplate? initialTemplate;
+
   @override
   State<SourceFormScreen> createState() => _SourceFormScreenState();
 }
@@ -14,119 +21,192 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   final key = GlobalKey<FormState>();
   final title = TextEditingController();
   final storage = const FlutterSecureStorage(
-      aOptions: AndroidOptions(encryptedSharedPreferences: true));
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
+
   @override
   void initState() {
     super.initState();
-    _select(sourceTemplates.first);
+    _select(widget.initialTemplate ?? sourceTemplates.first);
   }
 
   void _select(SourceTemplate next) {
     template = next;
-    for (final c in values.values) c.dispose();
+    for (final controller in values.values) {
+      controller.dispose();
+    }
     values.clear();
-    for (final f in next.fields)
-      values[f.id] = TextEditingController(text: f.initialValue);
+    for (final field in next.fields) {
+      values[field.id] = TextEditingController(text: field.initialValue);
+    }
   }
 
   Future<void> submit() async {
-    if (!key.currentState!.validate()) return;
+    if (!key.currentState!.validate()) {
+      return;
+    }
     final token = await storage.read(key: 'github_pat');
     if (token == null || token.isEmpty) {
-      if (mounted)
+      if (mounted) {
         await Navigator.push(
-            context, MaterialPageRoute(builder: (_) => const SettingsScreen()));
+          context,
+          MaterialPageRoute(builder: (_) => const SettingsScreen()),
+        );
+      }
       return;
     }
     setState(() => busy = true);
     try {
-      final map = values.map((k, v) => MapEntry(k, v.text));
+      final map = values.map((key, value) => MapEntry(key, value.text));
       final url = await GitHubService(token).createIssue(
-          title: '${template.titlePrefix}${title.text.trim()}',
-          body: GitHubService.issueBody(template, map));
+        title: '${template.titlePrefix}${title.text.trim()}',
+        body: GitHubService.issueBody(template, map),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Issue erstellt: $url')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Issue erstellt: $url')),
+        );
         title.clear();
-        for (final f in template.fields) values[f.id]!.text = f.initialValue;
+        for (final field in template.fields) {
+          values[field.id]!.text = field.initialValue;
+        }
         setState(() {});
       }
-    } catch (e) {
-      if (mounted)
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Fehler: $e')));
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Fehler: $error')),
+        );
+      }
     } finally {
-      if (mounted) setState(() => busy = false);
+      if (mounted) {
+        setState(() => busy = false);
+      }
     }
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-      appBar: AppBar(title: const Text('Wiki-Quelle erfassen'), actions: [
-        IconButton(
-            onPressed: () => Navigator.push(context,
-                MaterialPageRoute(builder: (_) => const SettingsScreen())),
-            icon: const Icon(Icons.settings))
-      ]),
+  void dispose() {
+    title.dispose();
+    for (final controller in values.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wiki-Quelle erfassen'),
+        actions: [
+          IconButton(
+            tooltip: 'Einstellungen öffnen',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+            ),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
       body: Form(
-          key: key,
-          child: ListView(padding: const EdgeInsets.all(16), children: [
+        key: key,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
             DropdownButtonFormField<SourceTemplate>(
-                value: template,
-                decoration: const InputDecoration(labelText: 'Quellentyp'),
-                items: sourceTemplates
-                    .map((t) => DropdownMenuItem(value: t, child: Text(t.name)))
-                    .toList(),
-                onChanged: (t) => setState(() => _select(t!))),
+              value: template,
+              decoration: const InputDecoration(labelText: 'Quellentyp'),
+              items: sourceTemplates
+                  .map(
+                    (item) => DropdownMenuItem(
+                      value: item,
+                      child: Text(item.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (selected) {
+                if (selected != null) {
+                  setState(() => _select(selected));
+                }
+              },
+            ),
             Padding(
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                child: Text(template.description)),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Text(template.description),
+            ),
             TextFormField(
-                controller: title,
-                decoration: InputDecoration(
-                    labelText: 'Issue-Titel', prefixText: template.titlePrefix),
-                validator: (v) =>
-                    (v ?? '').trim().isEmpty ? 'Pflichtfeld' : null),
+              controller: title,
+              decoration: InputDecoration(
+                labelText: 'Issue-Titel',
+                prefixText: template.titlePrefix,
+              ),
+              validator: (value) =>
+                  (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null,
+            ),
             const SizedBox(height: 12),
             ...template.fields.map(_field),
             const SizedBox(height: 20),
             FilledButton.icon(
-                onPressed: busy ? null : submit,
-                icon: const Icon(Icons.cloud_upload),
-                label: Text(busy
+              onPressed: busy ? null : submit,
+              icon: const Icon(Icons.cloud_upload),
+              label: Text(
+                busy
                     ? 'Wird erstellt …'
-                    : 'Issue mit Label „quelle“ erstellen')),
-          ])));
-  Widget _field(SourceField f) {
-    final c = values[f.id]!;
-    if (f.kind == FieldKind.dropdown)
+                    : 'Issue mit Label „quelle“ erstellen',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _field(SourceField field) {
+    final controller = values[field.id]!;
+    if (field.kind == FieldKind.dropdown) {
       return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: DropdownButtonFormField<String>(
-              value: c.text.isEmpty ? null : c.text,
-              decoration: InputDecoration(
-                  labelText: f.label, helperText: f.description),
-              items: f.options
-                  .map((o) => DropdownMenuItem(value: o, child: Text(o)))
-                  .toList(),
-              onChanged: (v) => c.text = v ?? '',
-              validator: (v) =>
-                  f.required && v == null ? 'Pflichtfeld' : null));
-    return Padding(
         padding: const EdgeInsets.only(bottom: 12),
-        child: TextFormField(
-            controller: c,
-            minLines: f.kind == FieldKind.textarea ? 3 : 1,
-            maxLines: f.kind == FieldKind.textarea ? 8 : 1,
-            decoration: InputDecoration(
-                labelText: f.label,
-                helperText: f.description,
-                hintText: f.placeholder,
-                alignLabelWithHint: true),
-            validator: (v) =>
-                f.required && (v ?? '').trim().isEmpty ? 'Pflichtfeld' : null));
+        child: DropdownButtonFormField<String>(
+          value: controller.text.isEmpty ? null : controller.text,
+          decoration: InputDecoration(
+            labelText: field.label,
+            helperText: field.description,
+          ),
+          items: field.options
+              .map(
+                (option) => DropdownMenuItem(
+                  value: option,
+                  child: Text(option),
+                ),
+              )
+              .toList(),
+          onChanged: (value) => controller.text = value ?? '',
+          validator: (value) =>
+              field.required && value == null ? 'Pflichtfeld' : null,
+        ),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: TextFormField(
+        controller: controller,
+        minLines: field.kind == FieldKind.textarea ? 3 : 1,
+        maxLines: field.kind == FieldKind.textarea ? 8 : 1,
+        decoration: InputDecoration(
+          labelText: field.label,
+          helperText: field.description,
+          hintText: field.placeholder,
+          alignLabelWithHint: true,
+        ),
+        validator: (value) => field.required && (value ?? '').trim().isEmpty
+            ? 'Pflichtfeld'
+            : null,
+      ),
+    );
   }
 }

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+import '../models/created_issue.dart';
 import '../models/source_template.dart';
+import '../models/wiki_configuration.dart';
+import '../services/configuration_service.dart';
+import '../services/external_url_service.dart';
 import '../services/github_service.dart';
 import 'settings_screen.dart';
 
@@ -20,12 +23,13 @@ class SourceFormScreen extends StatefulWidget {
 class _SourceFormScreenState extends State<SourceFormScreen> {
   final key = GlobalKey<FormState>();
   final title = TextEditingController();
-  final storage = const FlutterSecureStorage(
-    aOptions: AndroidOptions(encryptedSharedPreferences: true),
-  );
+  final _configurationService = ConfigurationService();
+  final _externalUrlService = ExternalUrlService();
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
+  CreatedIssue? _createdIssue;
+  String? _errorMessage;
 
   @override
   void initState() {
@@ -42,50 +46,79 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     for (final field in next.fields) {
       values[field.id] = TextEditingController(text: field.initialValue);
     }
+    _createdIssue = null;
+    _errorMessage = null;
   }
 
   Future<void> submit() async {
     if (!key.currentState!.validate()) {
       return;
     }
-    final token = await storage.read(key: 'github_pat');
-    if (token == null || token.isEmpty) {
-      if (mounted) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const SettingsScreen()),
-        );
-      }
-      return;
-    }
-    setState(() => busy = true);
+
+    setState(() {
+      busy = true;
+      _errorMessage = null;
+    });
     try {
+      final configuration = await _configurationService.load();
+      final repository = _repositoryFrom(configuration);
       final map = values.map((key, value) => MapEntry(key, value.text));
-      final url = await GitHubService(token).createIssue(
+      final issue = await GitHubService(
+        configuration.token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).createIssue(
         title: '${template.titlePrefix}${title.text.trim()}',
         body: GitHubService.issueBody(template, map),
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Issue erstellt: $url')),
-        );
-        title.clear();
-        for (final field in template.fields) {
-          values[field.id]!.text = field.initialValue;
-        }
-        setState(() {});
+        setState(() => _createdIssue = issue);
       }
     } catch (error) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Fehler: $error')),
-        );
+        setState(() {
+          _errorMessage = 'Quelle konnte nicht erstellt werden: $error';
+        });
       }
     } finally {
       if (mounted) {
         setState(() => busy = false);
       }
     }
+  }
+
+  GitHubRepository _repositoryFrom(WikiConfiguration configuration) {
+    if (!configuration.isComplete) {
+      throw const FormatException(
+        'Wiki-Konfiguration ist unvollständig. Einstellungen prüfen.',
+      );
+    }
+    return GitHubRepository.parse(configuration.repositoryUrl);
+  }
+
+  Future<void> _openCreatedIssue() async {
+    final issue = _createdIssue;
+    if (issue == null) {
+      return;
+    }
+    try {
+      await _externalUrlService.open(issue.url);
+    } catch (error) {
+      if (mounted) {
+        setState(() => _errorMessage = 'Issue konnte nicht geöffnet werden: $error');
+      }
+    }
+  }
+
+  void _startNewSource() {
+    title.clear();
+    for (final field in template.fields) {
+      values[field.id]!.text = field.initialValue;
+    }
+    setState(() {
+      _createdIssue = null;
+      _errorMessage = null;
+    });
   }
 
   @override
@@ -129,18 +162,23 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                     ),
                   )
                   .toList(),
-              onChanged: (selected) {
-                if (selected != null) {
-                  setState(() => _select(selected));
-                }
-              },
+              onChanged: busy
+                  ? null
+                  : (selected) {
+                      if (selected != null) {
+                        setState(() => _select(selected));
+                      }
+                    },
             ),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 12),
               child: Text(template.description),
             ),
+            if (_createdIssue != null) _successCard(_createdIssue!),
+            if (_errorMessage != null) _errorCard(_errorMessage!),
             TextFormField(
               controller: title,
+              enabled: !busy,
               decoration: InputDecoration(
                 labelText: 'Issue-Titel',
                 prefixText: template.titlePrefix,
@@ -154,13 +192,60 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             FilledButton.icon(
               onPressed: busy ? null : submit,
               icon: const Icon(Icons.cloud_upload),
-              label: Text(
-                busy
-                    ? 'Wird erstellt …'
-                    : 'Issue mit Label „quelle“ erstellen',
-              ),
+              label: Text(busy ? 'Wird erstellt …' : 'Quelle speichern'),
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _successCard(CreatedIssue issue) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Quelle erstellt – Issue #${issue.number}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: _openCreatedIssue,
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('Issue öffnen'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: _startNewSource,
+                  icon: const Icon(Icons.add),
+                  label: const Text('Neue Quelle'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _errorCard(String message) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Semantics(
+          liveRegion: true,
+          child: Text(
+            message,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
         ),
       ),
     );
@@ -185,7 +270,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                 ),
               )
               .toList(),
-          onChanged: (value) => controller.text = value ?? '',
+          onChanged: busy ? null : (value) => controller.text = value ?? '',
           validator: (value) =>
               field.required && value == null ? 'Pflichtfeld' : null,
         ),
@@ -195,6 +280,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       padding: const EdgeInsets.only(bottom: 12),
       child: TextFormField(
         controller: controller,
+        enabled: !busy,
         minLines: field.kind == FieldKind.textarea ? 3 : 1,
         maxLines: field.kind == FieldKind.textarea ? 8 : 1,
         decoration: InputDecoration(

--- a/lib/services/configuration_service.dart
+++ b/lib/services/configuration_service.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/wiki_configuration.dart';
+
+class ConfigurationService {
+  ConfigurationService({FlutterSecureStorage? storage})
+      : _storage = storage ??
+            const FlutterSecureStorage(
+              aOptions: AndroidOptions(encryptedSharedPreferences: true),
+            );
+
+  static const _tokenKey = 'github_pat';
+  static const _repositoryKey = 'wiki_repository_url';
+
+  final FlutterSecureStorage _storage;
+
+  Future<WikiConfiguration> load() async {
+    final token = await _storage.read(key: _tokenKey) ?? '';
+    final repositoryUrl = await _storage.read(key: _repositoryKey) ??
+        WikiConfiguration.defaultRepositoryUrl;
+    return WikiConfiguration(repositoryUrl: repositoryUrl, token: token);
+  }
+
+  Future<void> save(WikiConfiguration configuration) async {
+    await _storage.write(
+      key: _repositoryKey,
+      value: configuration.repositoryUrl.trim(),
+    );
+    await _storage.write(
+      key: _tokenKey,
+      value: configuration.token.trim(),
+    );
+  }
+}

--- a/lib/services/external_url_service.dart
+++ b/lib/services/external_url_service.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/services.dart';
+
+class ExternalUrlService {
+  static const _channel = MethodChannel('developer_wiki/external_url');
+
+  Future<void> open(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) {
+      throw const FormatException('Ungültiger Link.');
+    }
+    await _channel.invokeMethod<void>('open', {'url': url});
+  }
+}

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/created_issue.dart';
+import '../models/source_issue_summary.dart';
 import '../models/source_template.dart';
 
 class GitHubService {
@@ -45,6 +46,40 @@ class GitHubService {
       number: data['number'] as int,
       url: data['html_url'] as String,
     );
+  }
+
+  Future<List<SourceIssueSummary>> listRecentSourceIssues({
+    int limit = 10,
+  }) async {
+    final uri = Uri.parse(
+      'https://api.github.com/repos/$owner/$repo/issues',
+    ).replace(
+      queryParameters: {
+        'state': 'all',
+        'labels': 'quelle',
+        'per_page': limit.toString(),
+        'sort': 'created',
+        'direction': 'desc',
+      },
+    );
+    final response = await _client.get(uri, headers: _headers);
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
+
+    final data = jsonDecode(response.body) as List<dynamic>;
+    return data
+        .cast<Map<String, dynamic>>()
+        .where((issue) => !issue.containsKey('pull_request'))
+        .map(
+          (issue) => SourceIssueSummary(
+            number: issue['number'] as int,
+            title: issue['title'] as String,
+            isOpen: issue['state'] == 'open',
+            url: issue['html_url'] as String,
+          ),
+        )
+        .toList();
   }
 
   Future<String> login() async {

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../models/created_issue.dart';
 import '../models/source_template.dart';
 
 class GitHubService {
@@ -21,7 +22,7 @@ class GitHubService {
         'X-GitHub-Api-Version': '2022-11-28',
       };
 
-  Future<String> createIssue({
+  Future<CreatedIssue> createIssue({
     required String title,
     required String body,
   }) async {
@@ -37,8 +38,11 @@ class GitHubService {
     if (response.statusCode != 201) {
       throw Exception(_message(response));
     }
-    return (jsonDecode(response.body) as Map<String, dynamic>)['html_url']
-        as String;
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return CreatedIssue(
+      number: data['number'] as int,
+      url: data['html_url'] as String,
+    );
   }
 
   Future<String> login() async {

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -1,54 +1,89 @@
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
+
 import '../models/source_template.dart';
 
 class GitHubService {
-  GitHubService(this.token,
-      {this.owner = 'Huluvu424242', this.repo = 'Developer-Wiki'});
-  final String token, owner, repo;
+  GitHubService(
+    this.token, {
+    this.owner = 'Huluvu424242',
+    this.repo = 'Developer-Wiki',
+  });
+
+  final String token;
+  final String owner;
+  final String repo;
+
   Map<String, String> get _headers => {
         'Accept': 'application/vnd.github+json',
         'Authorization': 'Bearer $token',
-        'X-GitHub-Api-Version': '2022-11-28'
+        'X-GitHub-Api-Version': '2022-11-28',
       };
 
-  Future<String> createIssue(
-      {required String title, required String body}) async {
+  Future<String> createIssue({
+    required String title,
+    required String body,
+  }) async {
     final response = await http.post(
-        Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
-        headers: {..._headers, 'Content-Type': 'application/json'},
-        body: jsonEncode({
-          'title': title,
-          'body': body,
-          'labels': ['quelle']
-        }));
-    if (response.statusCode != 201) throw Exception(_message(response));
+      Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
+      headers: {..._headers, 'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'title': title,
+        'body': body,
+        'labels': ['quelle'],
+      }),
+    );
+    if (response.statusCode != 201) {
+      throw Exception(_message(response));
+    }
     return (jsonDecode(response.body) as Map<String, dynamic>)['html_url']
         as String;
   }
 
   Future<String> login() async {
-    final response = await http.get(Uri.parse('https://api.github.com/user'),
-        headers: _headers);
-    if (response.statusCode != 200) throw Exception(_message(response));
+    final response = await http.get(
+      Uri.parse('https://api.github.com/user'),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
     return (jsonDecode(response.body) as Map<String, dynamic>)['login']
         as String;
   }
 
+  Future<String> verifyRepositoryAccess() async {
+    final loginName = await login();
+    final response = await http.get(
+      Uri.parse('https://api.github.com/repos/$owner/$repo'),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
+    return loginName;
+  }
+
   static String issueBody(
-          SourceTemplate template, Map<String, String> values) =>
+    SourceTemplate template,
+    Map<String, String> values,
+  ) =>
       template.fields
-          .where((f) => (values[f.id] ?? '').trim().isNotEmpty)
-          .map((f) => '### ${f.label}\n\n${values[f.id]!.trim()}')
+          .where((field) => (values[field.id] ?? '').trim().isNotEmpty)
+          .map(
+            (field) =>
+                '### ${field.label}\n\n${values[field.id]!.trim()}',
+          )
           .join('\n\n');
 
-  static String _message(http.Response r) {
+  static String _message(http.Response response) {
     try {
-      return (jsonDecode(r.body) as Map<String, dynamic>)['message']
+      return (jsonDecode(response.body) as Map<String, dynamic>)['message']
               ?.toString() ??
-          'HTTP ${r.statusCode}';
+          'HTTP ${response.statusCode}';
     } catch (_) {
-      return 'HTTP ${r.statusCode}';
+      return 'HTTP ${response.statusCode}';
     }
   }
 }

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -10,11 +10,13 @@ class GitHubService {
     this.token, {
     this.owner = 'Huluvu424242',
     this.repo = 'Developer-Wiki',
-  });
+    http.Client? client,
+  }) : _client = client ?? http.Client();
 
   final String token;
   final String owner;
   final String repo;
+  final http.Client _client;
 
   Map<String, String> get _headers => {
         'Accept': 'application/vnd.github+json',
@@ -26,7 +28,7 @@ class GitHubService {
     required String title,
     required String body,
   }) async {
-    final response = await http.post(
+    final response = await _client.post(
       Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
       headers: {..._headers, 'Content-Type': 'application/json'},
       body: jsonEncode({
@@ -46,7 +48,7 @@ class GitHubService {
   }
 
   Future<String> login() async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('https://api.github.com/user'),
       headers: _headers,
     );
@@ -59,7 +61,7 @@ class GitHubService {
 
   Future<String> verifyRepositoryAccess() async {
     final loginName = await login();
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('https://api.github.com/repos/$owner/$repo'),
       headers: _headers,
     );

--- a/test/github_service_test.dart
+++ b/test/github_service_test.dart
@@ -1,12 +1,53 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'dart:convert';
+
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/services/github_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 void main() {
   test('Issue-Body entspricht GitHub-Issue-Form-Struktur', () {
-    final body = GitHubService.issueBody(sourceTemplates.first,
-        {'source_title': 'Test', 'urls': 'https://example.org'});
-    expect(body,
-        '### Titel der Quelle\n\nTest\n\n### Link oder zusammengehörige Links\n\nhttps://example.org');
+    final body = GitHubService.issueBody(
+      sourceTemplates.first,
+      {'source_title': 'Test', 'urls': 'https://example.org'},
+    );
+    expect(
+      body,
+      '### Titel der Quelle\n\nTest\n\n### Link oder zusammengehörige Links\n\nhttps://example.org',
+    );
+  });
+
+  test('createIssue uses configured repository and source label', () async {
+    late http.Request capturedRequest;
+    final client = MockClient((request) async {
+      capturedRequest = request;
+      return http.Response(
+        jsonEncode({
+          'number': 123,
+          'html_url': 'https://github.com/example/wiki/issues/123',
+        }),
+        201,
+      );
+    });
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: client,
+    );
+
+    final issue = await service.createIssue(title: 'Title', body: 'Body');
+
+    expect(
+      capturedRequest.url.toString(),
+      'https://api.github.com/repos/example/wiki/issues',
+    );
+    final payload = jsonDecode(capturedRequest.body) as Map<String, dynamic>;
+    expect(payload['title'], 'Title');
+    expect(payload['body'], 'Body');
+    expect(payload['labels'], ['quelle']);
+    expect(issue.number, 123);
+    expect(issue.url, 'https://github.com/example/wiki/issues/123');
   });
 }

--- a/test/github_service_test.dart
+++ b/test/github_service_test.dart
@@ -50,4 +50,53 @@ void main() {
     expect(issue.number, 123);
     expect(issue.url, 'https://github.com/example/wiki/issues/123');
   });
+
+  test('listRecentSourceIssues loads source issues and excludes pull requests',
+      () async {
+    late http.Request capturedRequest;
+    final client = MockClient((request) async {
+      capturedRequest = request;
+      return http.Response(
+        jsonEncode([
+          {
+            'number': 42,
+            'title': 'Neue Quelle',
+            'state': 'open',
+            'html_url': 'https://github.com/example/wiki/issues/42',
+          },
+          {
+            'number': 41,
+            'title': 'Verarbeitete Quelle',
+            'state': 'closed',
+            'html_url': 'https://github.com/example/wiki/issues/41',
+          },
+          {
+            'number': 40,
+            'title': 'Pull Request',
+            'state': 'open',
+            'html_url': 'https://github.com/example/wiki/pull/40',
+            'pull_request': {'url': 'https://api.github.com/example'},
+          },
+        ]),
+        200,
+      );
+    });
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: client,
+    );
+
+    final issues = await service.listRecentSourceIssues();
+
+    expect(capturedRequest.url.queryParameters['labels'], 'quelle');
+    expect(capturedRequest.url.queryParameters['state'], 'all');
+    expect(capturedRequest.url.queryParameters['direction'], 'desc');
+    expect(issues, hasLength(2));
+    expect(issues.first.number, 42);
+    expect(issues.first.title, 'Neue Quelle');
+    expect(issues.first.isOpen, isTrue);
+    expect(issues[1].isOpen, isFalse);
+  });
 }

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,32 @@
+import 'package:developer_wiki_source_capture/models/source_template.dart';
+import 'package:developer_wiki_source_capture/screens/home_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('home screen offers sources, import and settings', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: HomeScreen()),
+    );
+
+    expect(find.text('Neue Quelle erfassen'), findsOneWidget);
+    expect(find.text('Quellen ins Wiki importieren'), findsOneWidget);
+    expect(find.byIcon(Icons.settings), findsOneWidget);
+    for (final template in sourceTemplates) {
+      expect(find.text(template.name), findsOneWidget);
+    }
+  });
+
+  testWidgets('selected source opens matching form', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: HomeScreen()),
+    );
+
+    final template = sourceTemplates.first;
+    await tester.tap(find.text(template.name));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Wiki-Quelle erfassen'), findsOneWidget);
+    expect(find.text(template.description), findsOneWidget);
+  });
+}

--- a/test/wiki_configuration_test.dart
+++ b/test/wiki_configuration_test.dart
@@ -1,0 +1,50 @@
+import 'package:developer_wiki_source_capture/models/wiki_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GitHubRepository.parse', () {
+    test('accepts full GitHub repository URL', () {
+      final repository = GitHubRepository.parse(
+        'https://github.com/Huluvu424242/Developer-Wiki',
+      );
+
+      expect(repository.owner, 'Huluvu424242');
+      expect(repository.name, 'Developer-Wiki');
+      expect(
+        repository.url,
+        'https://github.com/Huluvu424242/Developer-Wiki',
+      );
+    });
+
+    test('accepts owner/repo shorthand', () {
+      final repository = GitHubRepository.parse('example/wiki');
+
+      expect(repository.owner, 'example');
+      expect(repository.name, 'wiki');
+    });
+
+    test('rejects non GitHub URLs', () {
+      expect(
+        () => GitHubRepository.parse('https://example.org/example/wiki'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  test('configuration is complete only with repository and token', () {
+    expect(
+      const WikiConfiguration(
+        repositoryUrl: WikiConfiguration.defaultRepositoryUrl,
+        token: 'token',
+      ).isComplete,
+      isTrue,
+    );
+    expect(
+      const WikiConfiguration(
+        repositoryUrl: WikiConfiguration.defaultRepositoryUrl,
+        token: '',
+      ).isComplete,
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
Closes #23

## Umsetzung
- neue Ansicht `Letzte Quellen`, erreichbar von der Startseite
- lädt die zuletzt erfassten GitHub-Issues mit Label `quelle` aus dem konfigurierten Wiki
- zeigt mindestens Issue-Nummer, Titel und Zustand `offen`/`geschlossen`
- Einträge können über die bestehende externe URL-Integration direkt auf GitHub geöffnet werden
- Refresh per AppBar und Pull-to-refresh
- verständliche Lade-, Leer- und Fehlerzustände inklusive Wiederholen
- keine lokale Kopie vollständiger Issue-Inhalte

## Architektur
Die GitHub-Abfrage liegt im `GitHubService`, die kompakte fachliche Darstellung in `SourceIssueSummary`. Die UI erhält ausschließlich die für diese Ansicht benötigten Daten und kennt keine API-Payloads.

## Prüfungen
- Akzeptanzkriterien von #23 gegen die Implementierung geprüft
- HTTP-Test für Filter `quelle`, offenen/geschlossenen Zustand, Sortierung und Ausschluss von Pull Requests ergänzt
- Branch-Diff gegen Story #19 geprüft

`dart format`, `flutter analyze` und `flutter test` können über den verbundenen GitHub-Connector nicht lokal ausgeführt werden und sollten vor dem Merge lokal bzw. durch CI laufen.

## Abhängigkeit
Dieser PR ist auf `story/19-create-source-issue` gestapelt und sollte nach PR #29 gemergt werden. Er ist fachlich unabhängig von #20, #21 und #22.
