### PR TITLE
Fix sharedContent access after story 21 rebase

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -34,7 +34,7 @@ class _HomeScreenState extends State<HomeScreen> {
       MaterialPageRoute(
         builder: (_) => SourceFormScreen(
           initialTemplate: template,
-          sharedContent: sharedContent,
+          sharedContent: widget.sharedContent,
         ),
       ),
     );
@@ -126,7 +126,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final isShared = sharedContent != null;
+    final isShared = widget.sharedContent != null;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Developer Wiki'),

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:developer_wiki_source_capture/models/shared_content.dart';
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/screens/home_screen.dart';
 import 'package:flutter/material.dart';
@@ -44,5 +45,32 @@ void main() {
 
     expect(find.text('Wiki-Quelle erfassen'), findsOneWidget);
     expect(find.text(template.description), findsOneWidget);
+  });
+
+  testWidgets('shared content is forwarded to the selected source form',
+      (tester) async {
+    const sharedContent = SharedContent(
+      kind: SharedContentKind.link,
+      text: 'https://example.org/source',
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: HomeScreen(sharedContent: sharedContent),
+      ),
+    );
+
+    expect(find.text('Geteilten Inhalt erfassen'), findsOneWidget);
+    expect(find.text('Welche Quellenart ist das?'), findsOneWidget);
+
+    final template = sourceTemplates.first;
+    await tester.tap(find.text(template.name));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Geteilten Inhalt erfassen'), findsOneWidget);
+    expect(
+      find.text('Geteilter Inhalt wurde vorausgefüllt und kann bearbeitet werden.'),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
Closes #38

## Ursache
Story #20 hat `HomeScreen` um `sharedContent` erweitert. Story #21 hat denselben Screen für den Importzustand von `StatelessWidget` auf `StatefulWidget` umgebaut. Beim Rebase wurden zwei Zugriffe aus der alten Stateless-Implementierung unverändert übernommen. Dadurch wurde in `_HomeScreenState` auf ein nicht vorhandenes `sharedContent` statt auf `widget.sharedContent` zugegriffen.

## Änderung
- beide fehlerhaften Zugriffe in `home_screen.dart` auf `widget.sharedContent` umgestellt
- Share-Inhalt wird weiterhin an `SourceFormScreen` weitergereicht
- Widget-Test ergänzt, der den Share-Modus auf der Startseite und die Weitergabe an das Formular absichert

## Prüfungen
- Diff gegen `story/21-import-dispatch` geprüft: ausschließlich `home_screen.dart` und `home_screen_test.dart`
- bestehende Importlogik aus Story #21 bleibt unverändert
- bestehende Share-Logik aus Story #20 bleibt unverändert

Bitte lokal vor Merge ausführen:

```text
dart format lib/screens/home_screen.dart test/home_screen_test.dart
flutter analyze
flutter test
```

## Offene Punkte
Der Connector kann die lokale Flutter-Toolchain nicht ausführen. Die abschließende Analyse und Testausführung muss daher lokal erfolgen.