### PR TITLE
Fix regressions after story 23 rebase

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,59 +1,217 @@
 import 'package:flutter/material.dart';
 
+import '../models/shared_content.dart';
 import '../models/source_template.dart';
+import '../models/wiki_configuration.dart';
+import '../models/workflow_run.dart';
+import '../services/configuration_service.dart';
+import '../services/external_url_service.dart';
+import '../services/github_service.dart';
 import 'recent_sources_screen.dart';
 import 'settings_screen.dart';
 import 'source_form_screen.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key, this.onImportRequested});
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({
+    super.key,
+    this.onImportRequested,
+    this.sharedContent,
+  });
 
   final VoidCallback? onImportRequested;
+  final SharedContent? sharedContent;
 
-  void _openSource(BuildContext context, SourceTemplate template) {
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final _configurationService = ConfigurationService();
+  final _externalUrlService = ExternalUrlService();
+  bool _importBusy = false;
+  bool _statusBusy = false;
+  String? _importMessage;
+  bool _importFailed = false;
+  DateTime? _lastDispatchAt;
+  WorkflowRun? _workflowRun;
+
+  void _openSource(SourceTemplate template) {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => SourceFormScreen(initialTemplate: template),
+        builder: (_) => SourceFormScreen(
+          initialTemplate: template,
+          sharedContent: widget.sharedContent,
+        ),
       ),
     );
   }
 
-  void _openRecentSources(BuildContext context) {
+  void _openRecentSources() {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const RecentSourcesScreen()),
     );
   }
 
-  void _openSettings(BuildContext context) {
+  void _openSettings() {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const SettingsScreen()),
     );
   }
 
-  void _requestImport(BuildContext context) {
-    if (onImportRequested != null) {
-      onImportRequested!();
-      return;
-    }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Der Wiki-Import wird in Story #21 umgesetzt.'),
+  Future<void> _requestImport() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Quellenimport starten?'),
+        content: const Text(
+          'Der Import-Workflow des verbundenen Wikis wird jetzt gestartet.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Abbrechen'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Starten'),
+          ),
+        ],
       ),
     );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+
+    if (widget.onImportRequested != null) {
+      widget.onImportRequested!();
+      return;
+    }
+    await _dispatchImport();
+  }
+
+  Future<void> _dispatchImport() async {
+    final dispatchStartedAt = DateTime.now().toUtc();
+    setState(() {
+      _importBusy = true;
+      _importMessage = 'Import wird auf GitHub gestartet …';
+      _importFailed = false;
+      _workflowRun = null;
+    });
+    try {
+      final configuration = await _configurationService.load();
+      final repository = _repositoryFrom(configuration);
+      await GitHubService(
+        configuration.token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).dispatchWorkflow(workflow: configuration.workflowFile);
+      if (mounted) {
+        setState(() {
+          _lastDispatchAt = dispatchStartedAt.subtract(const Duration(seconds: 5));
+          _importMessage = 'Import gestartet. Status kann aktualisiert werden.';
+          _importFailed = false;
+        });
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _importMessage = 'Import konnte nicht gestartet werden: $error';
+          _importFailed = true;
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _importBusy = false);
+      }
+    }
+  }
+
+  Future<void> _refreshImportStatus() async {
+    final notBefore = _lastDispatchAt;
+    if (notBefore == null) {
+      return;
+    }
+    setState(() {
+      _statusBusy = true;
+      _importMessage = null;
+      _importFailed = false;
+    });
+    try {
+      final configuration = await _configurationService.load();
+      final repository = _repositoryFrom(configuration);
+      final run = await GitHubService(
+        configuration.token,
+        owner: repository.owner,
+        repo: repository.name,
+      ).latestWorkflowRun(
+        workflow: configuration.workflowFile,
+        notBefore: notBefore,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _workflowRun = run;
+        _importMessage = run == null
+            ? 'Noch kein passender Workflow-Lauf gefunden.'
+            : null;
+      });
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _importMessage = 'Importstatus konnte nicht geladen werden: $error';
+          _importFailed = true;
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _statusBusy = false);
+      }
+    }
+  }
+
+  Future<void> _openWorkflowRun() async {
+    final run = _workflowRun;
+    if (run == null) {
+      return;
+    }
+    try {
+      await _externalUrlService.open(run.url);
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _importMessage = 'Workflow-Lauf konnte nicht geöffnet werden: $error';
+          _importFailed = true;
+        });
+      }
+    }
+  }
+
+  GitHubRepository _repositoryFrom(WikiConfiguration configuration) {
+    if (!configuration.isComplete) {
+      throw const FormatException(
+        'Wiki-Konfiguration ist unvollständig. Einstellungen prüfen.',
+      );
+    }
+    if (configuration.workflowFile.trim().isEmpty) {
+      throw const FormatException('Import-Workflow ist nicht konfiguriert.');
+    }
+    return GitHubRepository.parse(configuration.repositoryUrl);
   }
 
   @override
   Widget build(BuildContext context) {
+    final isShared = widget.sharedContent != null;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Developer Wiki'),
         actions: [
           IconButton(
             tooltip: 'Einstellungen öffnen',
-            onPressed: () => _openSettings(context),
+            onPressed: _openSettings,
             icon: const Icon(Icons.settings),
           ),
         ],
@@ -62,11 +220,15 @@ class HomeScreen extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         children: [
           Text(
-            'Neue Quelle erfassen',
+            isShared ? 'Geteilten Inhalt erfassen' : 'Neue Quelle erfassen',
             style: Theme.of(context).textTheme.titleLarge,
           ),
           const SizedBox(height: 8),
-          const Text('Wähle die passende Quellenart aus.'),
+          Text(
+            isShared
+                ? 'Welche Quellenart ist das?'
+                : 'Wähle die passende Quellenart aus.',
+          ),
           const SizedBox(height: 16),
           ...sourceTemplates.map(
             (template) => Padding(
@@ -77,24 +239,87 @@ class HomeScreen extends StatelessWidget {
                   title: Text(template.name),
                   subtitle: Text(template.description),
                   trailing: const Icon(Icons.chevron_right),
-                  onTap: () => _openSource(context, template),
+                  onTap: () => _openSource(template),
                 ),
               ),
             ),
           ),
           const Divider(height: 32),
           OutlinedButton.icon(
-            onPressed: () => _openRecentSources(context),
+            onPressed: _openRecentSources,
             icon: const Icon(Icons.history),
             label: const Text('Letzte Quellen'),
           ),
           const SizedBox(height: 12),
           FilledButton.tonalIcon(
-            onPressed: () => _requestImport(context),
+            onPressed: _importBusy ? null : _requestImport,
             icon: const Icon(Icons.sync),
-            label: const Text('Quellen ins Wiki importieren'),
+            label: Text(
+              _importBusy
+                  ? 'Import wird gestartet …'
+                  : 'Quellen ins Wiki importieren',
+            ),
           ),
+          if (_lastDispatchAt != null) ...[
+            const SizedBox(height: 16),
+            _importStatusCard(),
+          ],
+          if (_importMessage != null) ...[
+            const SizedBox(height: 12),
+            Semantics(
+              liveRegion: true,
+              child: Text(
+                _importMessage!,
+                style: TextStyle(
+                  color: _importFailed
+                      ? Theme.of(context).colorScheme.error
+                      : null,
+                ),
+              ),
+            ),
+          ],
         ],
+      ),
+    );
+  }
+
+  Widget _importStatusCard() {
+    final run = _workflowRun;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Letzter gestarteter Import',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(run?.label ?? 'gestartet / wartet'),
+            if (run != null) Text('GitHub Actions #${run.id}'),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: _statusBusy ? null : _refreshImportStatus,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(
+                    _statusBusy ? 'Wird aktualisiert …' : 'Status aktualisieren',
+                  ),
+                ),
+                if (run != null)
+                  OutlinedButton.icon(
+                    onPressed: _openWorkflowRun,
+                    icon: const Icon(Icons.open_in_new),
+                    label: const Text('Auf GitHub öffnen'),
+                  ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -83,6 +83,64 @@ class GitHubService {
         .toList();
   }
 
+  Future<void> dispatchWorkflow({
+    required String workflow,
+    String ref = 'master',
+  }) async {
+    final workflowId = _workflowId(workflow);
+    final response = await _client.post(
+      Uri.parse(
+        'https://api.github.com/repos/$owner/$repo/actions/workflows/'
+        '$workflowId/dispatches',
+      ),
+      headers: {..._headers, 'Content-Type': 'application/json'},
+      body: jsonEncode({'ref': ref}),
+    );
+    if (response.statusCode != 204) {
+      throw Exception(_message(response));
+    }
+  }
+
+  Future<WorkflowRun?> latestWorkflowRun({
+    required String workflow,
+    DateTime? notBefore,
+  }) async {
+    final workflowId = _workflowId(workflow);
+    final uri = Uri.parse(
+      'https://api.github.com/repos/$owner/$repo/actions/workflows/'
+      '$workflowId/runs',
+    ).replace(
+      queryParameters: const {
+        'event': 'workflow_dispatch',
+        'per_page': '10',
+      },
+    );
+    final response = await _client.get(uri, headers: _headers);
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final runs = data['workflow_runs'] as List<dynamic>? ?? const [];
+    for (final rawRun in runs) {
+      final run = rawRun as Map<String, dynamic>;
+      final createdAt = DateTime.parse(run['created_at'] as String).toUtc();
+      if (notBefore != null && createdAt.isBefore(notBefore.toUtc())) {
+        continue;
+      }
+      return WorkflowRun(
+        id: run['id'] as int,
+        url: run['html_url'] as String,
+        state: _workflowRunState(
+          run['status']?.toString(),
+          run['conclusion']?.toString(),
+        ),
+        createdAt: createdAt,
+      );
+    }
+    return null;
+  }
+
   Future<String> login() async {
     final response = await _client.get(
       Uri.parse('https://api.github.com/user'),

--- a/test/github_service_test.dart
+++ b/test/github_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:developer_wiki_source_capture/models/source_template.dart';
+import 'package:developer_wiki_source_capture/models/workflow_run.dart';
 import 'package:developer_wiki_source_capture/services/github_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -98,5 +99,104 @@ void main() {
     expect(issues.first.title, 'Neue Quelle');
     expect(issues.first.isOpen, isTrue);
     expect(issues[1].isOpen, isFalse);
+  });
+
+  test('dispatchWorkflow uses configured workflow and master ref', () async {
+    late http.Request capturedRequest;
+    final client = MockClient((request) async {
+      capturedRequest = request;
+      return http.Response('', 204);
+    });
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: client,
+    );
+
+    await service.dispatchWorkflow(workflow: 'import-source-issues.yml');
+
+    expect(
+      capturedRequest.url.toString(),
+      'https://api.github.com/repos/example/wiki/actions/workflows/'
+      'import-source-issues.yml/dispatches',
+    );
+    expect(
+      jsonDecode(capturedRequest.body),
+      {'ref': 'master'},
+    );
+  });
+
+  test('latestWorkflowRun maps matching successful dispatch', () async {
+    late http.Request capturedRequest;
+    final client = MockClient((request) async {
+      capturedRequest = request;
+      return http.Response(
+        jsonEncode({
+          'workflow_runs': [
+            {
+              'id': 77,
+              'html_url': 'https://github.com/example/wiki/actions/runs/77',
+              'status': 'completed',
+              'conclusion': 'success',
+              'created_at': '2026-08-20T20:00:00Z',
+            },
+          ],
+        }),
+        200,
+      );
+    });
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: client,
+    );
+
+    final run = await service.latestWorkflowRun(
+      workflow: 'import-source-issues.yml',
+      notBefore: DateTime.parse('2026-08-20T19:59:00Z'),
+    );
+
+    expect(run, isNotNull);
+    expect(run!.id, 77);
+    expect(run.state, WorkflowRunState.successful);
+    expect(
+      capturedRequest.url.queryParameters['event'],
+      'workflow_dispatch',
+    );
+    expect(capturedRequest.url.queryParameters['per_page'], '10');
+  });
+
+  test('latestWorkflowRun ignores runs older than dispatch', () async {
+    final client = MockClient((request) async {
+      return http.Response(
+        jsonEncode({
+          'workflow_runs': [
+            {
+              'id': 76,
+              'html_url': 'https://github.com/example/wiki/actions/runs/76',
+              'status': 'in_progress',
+              'conclusion': null,
+              'created_at': '2026-08-20T19:58:00Z',
+            },
+          ],
+        }),
+        200,
+      );
+    });
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: client,
+    );
+
+    final run = await service.latestWorkflowRun(
+      workflow: 'import-source-issues.yml',
+      notBefore: DateTime.parse('2026-08-20T19:59:00Z'),
+    );
+
+    expect(run, isNull);
   });
 }


### PR DESCRIPTION
Closes #44

## Ursache
Beim Rebase von `story/23-recent-sources-rebased` wurden ältere Versionen gemeinsamer Dateien übernommen. Dadurch hat Story #23 bereits gemergte Funktionen aus #20, #21 und #22 überschrieben, statt ihre Änderungen additiv auf den aktuellen `master` aufzusetzen.

## Änderung
- aktuellen `HomeScreen` aus `master` vollständig erhalten und nur die Aktion `Letzte Quellen` sowie die Navigation zu `RecentSourcesScreen` ergänzt
- aktuellen `GitHubService` vollständig erhalten und nur `listRecentSourceIssues()` sowie das neue Summary-Modell integriert
- bestehende Workflow-Tests aus `master` wiederhergestellt und den Test für `listRecentSourceIssues()` zusätzlich beibehalten
- `RecentSourcesScreen` und `SourceIssueSummary` aus Story #23 unverändert gelassen

## Prüfung
Der Vergleich des Fix-Branches gegen `master` enthält jetzt nur additive Story-23-Änderungen: keine Löschungen an bereits gemergter Funktionalität.

Bitte lokal vor Merge ausführen:

```text
dart format lib/screens/home_screen.dart lib/services/github_service.dart test/github_service_test.dart
flutter analyze
flutter test
```

## Offene Punkte
Die lokale Flutter-Toolchain kann über den GitHub-Connector nicht ausgeführt werden. Die abschließende statische Analyse und Testausführung muss daher lokal erfolgen.