### PR TITLE
Add signed Android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,147 @@
+name: Android Release APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Full Flutter version from pubspec.yaml, e.g. 0.1.0+1"
+        required: true
+        type: string
+      release_notes:
+        description: "Optional Markdown release notes"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: android-release-${{ inputs.release_version }}
+  cancel-in-progress: false
+
+jobs:
+  release-apk:
+    name: Build and publish Android APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          pubspec_version="$(sed -n 's/^version:[[:space:]]*//p' pubspec.yaml | head -n 1)"
+          if [ -z "${pubspec_version}" ]; then
+            echo "No version found in pubspec.yaml." >&2
+            exit 1
+          fi
+          if [ "${pubspec_version}" != "${RELEASE_VERSION}" ]; then
+            echo "release_version (${RELEASE_VERSION}) must match pubspec.yaml (${pubspec_version})." >&2
+            exit 1
+          fi
+          release_tag="v${RELEASE_VERSION}"
+          if git show-ref --tags --verify --quiet "refs/tags/${release_tag}"; then
+            echo "Release tag ${release_tag} already exists. Increase pubspec.yaml's version first." >&2
+            exit 1
+          fi
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test
+
+      - name: Decode Android release keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ANDROID_KEYSTORE_BASE64}" ]; then
+            echo "ANDROID_KEYSTORE_BASE64 secret is required for release signing. See README.md#android-release-per-github-actions." >&2
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/android-signing"
+          printf '%s' "${ANDROID_KEYSTORE_BASE64}" | base64 --decode > "$RUNNER_TEMP/android-signing/release.jks"
+
+      - name: Build Android release APK
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/android-signing/release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for secret_name in ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!secret_name}" ]; then
+              echo "${secret_name} secret is required for release signing. See README.md#android-release-per-github-actions." >&2
+              exit 1
+            fi
+          done
+          build_name="${RELEASE_VERSION%%+*}"
+          build_number="${RELEASE_VERSION##*+}"
+          flutter build apk --release --build-name "${build_name}" --build-number "${build_number}"
+
+      - name: Prepare release files
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          apk_name="developer-wiki-app-${RELEASE_VERSION}.apk"
+          cp build/app/outputs/flutter-apk/app-release.apk "release/${apk_name}"
+          (cd release && sha256sum "${apk_name}" > "${apk_name}.sha256")
+
+      - name: Write release notes
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          notes = event.get("inputs", {}).get("release_notes", "").strip()
+          if not notes:
+              version = os.environ["RELEASE_VERSION"]
+              notes = (
+                  f"Android release {version}\n\n"
+                  "- Built from the manually triggered GitHub Actions release workflow.\n"
+                  "- APK and SHA-256 checksum are attached below.\n"
+              )
+          Path("release-notes.md").write_text(notes + "\n", encoding="utf-8")
+          PY
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          gh release create "v${RELEASE_VERSION}" \
+            release/* \
+            --title "Developer Wiki App ${RELEASE_VERSION}" \
+            --notes-file release-notes.md \
+            --latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,73 @@ Release-APK:
 flutter build apk --release
 ```
 
-Vor einer Veröffentlichung muss eine eigene Android-Signatur konfiguriert werden.
+Für veröffentlichte APKs sollte die unten beschriebene stabile Android-Signatur verwendet werden.
+
+## Android-Release per GitHub Actions
+
+Für reproduzierbare, installierbare APKs gibt es den manuell startbaren Workflow **Android Release APK** unter `.github/workflows/android-release.yml`.
+
+Der Workflow:
+
+- prüft, dass `release_version` exakt der Version in `pubspec.yaml` entspricht,
+- führt `flutter analyze` und `flutter test` aus,
+- lädt einen stabilen Android-Keystore ausschließlich aus GitHub Actions Secrets,
+- baut eine signierte Release-APK,
+- erzeugt eine SHA-256-Prüfsumme,
+- veröffentlicht APK und Prüfsumme als GitHub Release `v<release_version>`.
+
+### Warum ein stabiler Keystore notwendig ist
+
+Android-APKs müssen signiert sein. Für spätere Updates muss außerdem immer derselbe Signaturschlüssel verwendet werden. Der private Keystore darf deshalb nicht in das Repository eingecheckt werden, sondern wird GitHub Actions verschlüsselt als Secret bereitgestellt.
+
+Wenn bereits eine APK mit einem anderen Schlüssel installiert wurde, kann Android das Update verweigern. In diesem Fall muss die alte Installation einmalig deinstalliert werden. Danach funktionieren Updates, solange derselbe Release-Keystore weiterverwendet wird.
+
+### Keystore unter Windows/PowerShell erzeugen
+
+Beispiel:
+
+```powershell
+keytool -genkeypair `
+  -v `
+  -keystore developer-wiki-app-release.jks `
+  -keyalg RSA `
+  -keysize 2048 `
+  -validity 10000 `
+  -alias developer-wiki-app
+```
+
+Den Keystore danach als Base64-String für GitHub Actions kodieren:
+
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("developer-wiki-app-release.jks")) | Set-Clipboard
+```
+
+Optional zusätzlich in eine Datei schreiben:
+
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("developer-wiki-app-release.jks")) | Set-Content -NoNewline "developer-wiki-app-release.jks.base64.txt"
+```
+
+### Benötigte GitHub Actions Secrets
+
+Unter **Settings → Secrets and variables → Actions → New repository secret** folgende Secrets anlegen:
+
+- `ANDROID_KEYSTORE_BASE64`: Base64-Inhalt der `.jks`-Datei
+- `ANDROID_KEYSTORE_PASSWORD`: Passwort des Keystores
+- `ANDROID_KEY_ALIAS`: Alias, z. B. `developer-wiki-app`
+- `ANDROID_KEY_PASSWORD`: Passwort des Schlüssels
+
+### Release ausführen
+
+1. `pubspec.yaml` auf eine neue Version im Format `MAJOR.MINOR.PATCH+BUILD` setzen, z. B. `0.1.1+2`.
+2. Änderung mergen.
+3. In GitHub **Actions → Android Release APK → Run workflow** öffnen.
+4. `release_version` exakt wie in `pubspec.yaml` eintragen.
+5. Optional Release Notes in Markdown erfassen.
+6. Workflow starten.
+7. Nach erfolgreichem Lauf das erzeugte GitHub Release öffnen und die APK herunterladen.
+
+Die Gradle-Konfiguration liest die Signing-Daten nur aus Umgebungsvariablen bzw. Gradle-Properties. Lokale Release-Builds ohne diese Werte behalten die Debug-Signatur als Fallback; veröffentlichte Builds über GitHub Actions verwenden dagegen zwingend den stabilen Release-Keystore.
 
 ## Architekturentscheidung
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,6 +4,18 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+fun releaseSigningValue(name: String): String? =
+    (project.findProperty(name) as String?)
+        ?.takeIf { it.isNotBlank() }
+        ?: System.getenv(name)?.takeIf { it.isNotBlank() }
+
+val hasReleaseSigningConfig = listOf(
+    "ANDROID_KEYSTORE_PATH",
+    "ANDROID_KEYSTORE_PASSWORD",
+    "ANDROID_KEY_ALIAS",
+    "ANDROID_KEY_PASSWORD",
+).all { releaseSigningValue(it) != null }
+
 android {
     namespace = "de.huluvu.developer_wiki_source_capture"
     compileSdk = 35
@@ -23,6 +35,25 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "0.1.0"
+    }
+
+    signingConfigs {
+        if (hasReleaseSigningConfig) {
+            create("release") {
+                storeFile = file(releaseSigningValue("ANDROID_KEYSTORE_PATH")!!)
+                storePassword = releaseSigningValue("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = releaseSigningValue("ANDROID_KEY_ALIAS")
+                keyPassword = releaseSigningValue("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            signingConfig = signingConfigs.getByName(
+                if (hasReleaseSigningConfig) "release" else "debug",
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Closes #46

## Ursache
Die App hatte bislang keine stabile Release-Signing-Konfiguration und keinen zentralen Release-Prozess. Dadurch war ein lokal erzeugtes APK für die Installation/Verteilung nicht zuverlässig geeignet.

## Lösung
- Android-Release-Signing über Umgebungsvariablen bzw. Gradle-Properties ergänzt.
- Manuell startbaren GitHub-Actions-Workflow `Android Release APK` hinzugefügt.
- Workflow prüft Version, führt `flutter analyze` und `flutter test` aus, lädt den Keystore ausschließlich aus GitHub Secrets, baut die signierte APK, erzeugt SHA-256 und veröffentlicht beides als GitHub Release.
- README um die einmalige Keystore-/Secret-Konfiguration und die Bedienung des Workflows ergänzt.

## Prüfungen
- Änderungen gegen `master` geprüft; Branch ist 3 Commits voraus und nicht hinter `master`.
- Workflow übernimmt das bereits bewährte Signing-/Release-Muster aus `ki-campus-companion-app`.
- Eine tatsächliche GitHub-Actions-Ausführung ist vor dem Merge nicht möglich, weil der Workflow und die Secrets erst auf dem Zielbranch verfügbar sein müssen.

## Nach dem Merge
Einmalig die vier dokumentierten Actions-Secrets anlegen und anschließend `Actions → Android Release APK → Run workflow` ausführen. Die `release_version` muss exakt der Version in `pubspec.yaml` entsprechen.