### PR TITLE
Upgrade setup-java action to v5

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"


### PR DESCRIPTION
## Änderung
- Aktualisiert `actions/setup-java` im Android-Release-Workflow von `v4` auf `v5`.
- Java-Version bleibt unverändert auf `21`.

## Prüfung
- Nur `.github/workflows/android-release.yml` geändert.
- Keine Änderungen an Build-Logik, Secrets oder Release-Versionierung.