### PR TITLE
Upgrade checkout action to Node 24 runtime

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Closes #49

## Ursache
Der Release-Workflow verwendete weiterhin `actions/checkout@v4`. Diese Action basiert auf Node 20, weshalb GitHub trotz fehlender eigener Node-Konfiguration eine Node-20-Abkündigung melden kann.

## Lösung
- `actions/checkout@v4` auf `actions/checkout@v6` aktualisiert.
- `fetch-depth: 0` unverändert beibehalten.
- Java-, Flutter-, Signing- und Release-Logik nicht verändert.

## Prüfung
- Aktuellen `master` geprüft: `actions/setup-java` steht bereits auf `v5`, aber Checkout noch auf `v4`.
- Laut offizieller `actions/checkout`-Dokumentation verwendet v5+ den Node-24-Runtime; v6 ist die aktuelle Hauptversion.
- Änderung umfasst genau eine Zeile im Release-Workflow.

## Verbleibende Unsicherheit
Falls nach dem Merge weiterhin eine Node-20-Meldung erscheint, muss der konkrete Run-Log geprüft werden. Ein weiterer möglicher indirekter Verursacher wäre eine intern verwendete Action innerhalb `subosito/flutter-action@v2`; der direkte Node-20-Verursacher im eigenen Workflow ist mit dieser Änderung jedoch beseitigt.