### PR TITLE
Upgrade Kotlin Gradle Plugin to 2.2.20

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.13.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 rootProject.name = "developer_wiki_source_capture"
 include(":app")


### PR DESCRIPTION
Closes #58

## Ursache
Nach dem AGP-/Gradle-Update scheitert Flutter weiterhin an der Kotlin-Plugin-Version. Der Remote-Branch `fix/update-agp` enthält noch `org.jetbrains.kotlin.android` 1.8.22; die lokale Fehlermeldung nennt 2.0.0. Im Repository ist jedoch keine zweite eingecheckte Kotlin-Version 2.0.0 vorhanden. Beide Werte liegen unter Flutters Mindestanforderung 2.2.20.

## Lösung
- `org.jetbrains.kotlin.android` in `android/settings.gradle.kts` auf `2.2.20` aktualisiert.
- Keine Änderungen an AGP, Gradle Wrapper, Java, Signing oder App-Logik.

## Prüfung
- Branch basiert direkt auf `fix/update-agp`.
- Vergleich gegen `fix/update-agp`: genau eine Datei, eine Addition und eine Löschung.
- Keine weitere Kotlin-Versionsdeklaration im versionierten Android-Build gefunden.

## Verbleibende Unsicherheit
Die lokal gemeldete Version 2.0.0 lässt sich im Remote-Repository nicht reproduzieren. Nach Merge in `fix/update-agp` sollte lokal `git pull`, anschließend Gradle-Sync bzw. `flutter analyze` ausgeführt werden. Falls weiterhin 2.0.0 gemeldet wird, ist der lokale Checkout/Gradle-Cache separat zu prüfen.