### PR TITLE
Raise compileSdk to 36

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ val hasReleaseSigningConfig = listOf(
 
 android {
     namespace = "de.huluvu.developer_wiki_source_capture"
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
Closes #60

## Ursache
Der lokale Gradle-Sync ist nach den Toolchain-Updates erfolgreich, meldet aber, dass `path_provider_android` eine Android SDK-Version 36 oder höher zum Kompilieren benötigt. Auf `fix/update-agp` steht `compileSdk` noch auf 35.

## Lösung
- `compileSdk` in `android/app/build.gradle.kts` von `35` auf `36` erhöht.
- `targetSdk` bewusst unverändert auf `35` belassen.
- Keine Änderungen an AGP, Gradle, Kotlin, Java, Signing oder App-Logik.

## Prüfung
- Branch basiert direkt auf `fix/update-agp`.
- Vergleich gegen `fix/update-agp`: genau eine Datei, eine Addition und eine Löschung.
- `pubspec.lock` enthält `path_provider_android` 2.2.19.

## Verbleibende Unsicherheit
Der eigentliche Android-Build kann über den Connector nicht lokal ausgeführt werden. Nach Merge in `fix/update-agp` sollte lokal erneut Gradle Sync sowie `flutter analyze`/`flutter test` geprüft werden.