### PR TITLE
Improve source form ergonomics and validation feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 ### Changed
 
 - README nach der Struktur von Standard Readme neu gegliedert und mit der weiterführenden Dokumentation verknüpft.
+- Quellenformular ergonomischer gestaltet: zusätzlicher Abstand unter dem Speichern-Button, temporärer Validierungshinweis und Löschaktionen für befüllte Eingabefelder.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -25,6 +25,8 @@ class SourceFormScreen extends StatefulWidget {
 }
 
 class _SourceFormScreenState extends State<SourceFormScreen> {
+  static const _bottomClearance = 64.0;
+
   final key = GlobalKey<FormState>();
   final title = TextEditingController();
   final _configurationService = ConfigurationService();
@@ -65,6 +67,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
 
   Future<void> submit() async {
     if (!key.currentState!.validate()) {
+      _showValidationHint();
       return;
     }
 
@@ -98,6 +101,18 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
         setState(() => busy = false);
       }
     }
+  }
+
+  void _showValidationHint() {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(
+          content: Text('Bitte markierte Pflichtfelder prüfen.'),
+          duration: Duration(seconds: 2),
+        ),
+      );
   }
 
   GitHubRepository _repositoryFrom(WikiConfiguration configuration) {
@@ -149,6 +164,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   @override
   Widget build(BuildContext context) {
     final sharedContent = widget.sharedContent;
+    final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -173,7 +189,9 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
           padding: const EdgeInsets.all(16),
           children: [
             if (sharedContent != null) ...[
-              const Text('Geteilter Inhalt wurde vorausgefüllt und kann bearbeitet werden.'),
+              const Text(
+                'Geteilter Inhalt wurde vorausgefüllt und kann bearbeitet werden.',
+              ),
               const SizedBox(height: 12),
             ],
             DropdownButtonFormField<SourceTemplate>(
@@ -201,15 +219,19 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             ),
             if (_createdIssue != null) _successCard(_createdIssue!),
             if (_errorMessage != null) _errorCard(_errorMessage!),
-            TextFormField(
-              controller: title,
-              enabled: !busy,
-              decoration: InputDecoration(
-                labelText: 'Issue-Titel',
-                prefixText: template.titlePrefix,
+            ValueListenableBuilder<TextEditingValue>(
+              valueListenable: title,
+              builder: (context, value, _) => TextFormField(
+                controller: title,
+                enabled: !busy,
+                decoration: InputDecoration(
+                  labelText: 'Issue-Titel',
+                  prefixText: template.titlePrefix,
+                  suffixIcon: _clearButton(title, hasValue: value.text.isNotEmpty),
+                ),
+                validator: (value) =>
+                    (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null,
               ),
-              validator: (value) =>
-                  (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null,
             ),
             const SizedBox(height: 12),
             ...template.fields.map(_field),
@@ -219,9 +241,27 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               icon: const Icon(Icons.cloud_upload),
               label: Text(busy ? 'Wird erstellt …' : 'Quelle speichern'),
             ),
+            SizedBox(
+              key: const Key('source-form-bottom-clearance'),
+              height: _bottomClearance + bottomInset,
+            ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget? _clearButton(
+    TextEditingController controller, {
+    required bool hasValue,
+  }) {
+    if (!hasValue) {
+      return null;
+    }
+    return IconButton(
+      tooltip: 'Feld leeren',
+      onPressed: busy ? null : controller.clear,
+      icon: const Icon(Icons.clear),
     );
   }
 
@@ -281,42 +321,57 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     if (field.kind == FieldKind.dropdown) {
       return Padding(
         padding: const EdgeInsets.only(bottom: 12),
-        child: DropdownButtonFormField<String>(
-          initialValue: controller.text.isEmpty ? null : controller.text,
-          decoration: InputDecoration(
-            labelText: field.label,
-            helperText: field.description,
+        child: ValueListenableBuilder<TextEditingValue>(
+          valueListenable: controller,
+          builder: (context, value, _) => DropdownButtonFormField<String>(
+            key: ValueKey('${field.id}:${value.text}'),
+            initialValue: value.text.isEmpty ? null : value.text,
+            decoration: InputDecoration(
+              labelText: field.label,
+              helperText: field.description,
+              suffixIcon: _clearButton(
+                controller,
+                hasValue: value.text.isNotEmpty,
+              ),
+            ),
+            items: field.options
+                .map(
+                  (option) => DropdownMenuItem(
+                    value: option,
+                    child: Text(option),
+                  ),
+                )
+                .toList(),
+            onChanged: busy ? null : (selected) => controller.text = selected ?? '',
+            validator: (selected) =>
+                field.required && selected == null ? 'Pflichtfeld' : null,
           ),
-          items: field.options
-              .map(
-                (option) => DropdownMenuItem(
-                  value: option,
-                  child: Text(option),
-                ),
-              )
-              .toList(),
-          onChanged: busy ? null : (value) => controller.text = value ?? '',
-          validator: (value) =>
-              field.required && value == null ? 'Pflichtfeld' : null,
         ),
       );
     }
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
-      child: TextFormField(
-        controller: controller,
-        enabled: !busy,
-        minLines: field.kind == FieldKind.textarea ? 3 : 1,
-        maxLines: field.kind == FieldKind.textarea ? 8 : 1,
-        decoration: InputDecoration(
-          labelText: field.label,
-          helperText: field.description,
-          hintText: field.placeholder,
-          alignLabelWithHint: true,
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: controller,
+        builder: (context, value, _) => TextFormField(
+          controller: controller,
+          enabled: !busy,
+          minLines: field.kind == FieldKind.textarea ? 3 : 1,
+          maxLines: field.kind == FieldKind.textarea ? 8 : 1,
+          decoration: InputDecoration(
+            labelText: field.label,
+            helperText: field.description,
+            hintText: field.placeholder,
+            alignLabelWithHint: true,
+            suffixIcon: _clearButton(
+              controller,
+              hasValue: value.text.isNotEmpty,
+            ),
+          ),
+          validator: (value) => field.required && (value ?? '').trim().isEmpty
+              ? 'Pflichtfeld'
+              : null,
         ),
-        validator: (value) => field.required && (value ?? '').trim().isEmpty
-            ? 'Pflichtfeld'
-            : null,
       ),
     );
   }

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -1,0 +1,69 @@
+import 'package:developer_wiki_source_capture/models/source_template.dart';
+import 'package:developer_wiki_source_capture/screens/source_form_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows a temporary hint when validation fails', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SourceFormScreen(initialTemplate: sourceTemplates[1]),
+      ),
+    );
+
+    await tester.scrollUntilVisible(
+      find.text('Quelle speichern'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.text('Quelle speichern'));
+    await tester.pump();
+
+    expect(find.text('Bitte markierte Pflichtfelder prüfen.'), findsOneWidget);
+    expect(find.text('Pflichtfeld'), findsWidgets);
+  });
+
+  testWidgets('clears a default value with one tap', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SourceFormScreen(initialTemplate: sourceTemplates[1]),
+      ),
+    );
+
+    await tester.scrollUntilVisible(
+      find.byTooltip('Feld leeren'),
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(find.byTooltip('Feld leeren'), findsOneWidget);
+    await tester.tap(find.byTooltip('Feld leeren'));
+    await tester.pump();
+
+    expect(find.byTooltip('Feld leeren'), findsNothing);
+  });
+
+  testWidgets('keeps bottom clearance in addition to the safe-area inset', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            viewPadding: EdgeInsets.only(bottom: 24),
+          ),
+          child: SourceFormScreen(initialTemplate: sourceTemplates[1]),
+        ),
+      ),
+    );
+
+    final clearance = find.byKey(const Key('source-form-bottom-clearance'));
+    await tester.scrollUntilVisible(
+      clearance,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(tester.widget<SizedBox>(clearance).height, 88);
+  });
+}


### PR DESCRIPTION
Implements #64

## Umsetzung
- Unterhalb von `Quelle speichern` einen zusätzlichen Abstand von 64 px plus aktuellem Safe-Area-Inset eingeführt, damit Snackbars und Systemhinweise den Button nicht verdecken.
- Bei fehlgeschlagener Formularvalidierung erscheint zusätzlich kurz `Bitte markierte Pflichtfelder prüfen.` als Snackbar; die feldbezogenen Fehler bleiben bestehen.
- Titel, Textfelder, Textareas und befüllte dynamische Dropdown-Felder erhalten eine Löschaktion `Feld leeren`.
- Löschaktionen erscheinen nur bei vorhandenem Inhalt und funktionieren auch für Default-/Prefill-Werte.
- Bestehende Speicher- und GitHub-Logik unverändert gelassen.
- Widget-Tests für Validierungshinweis, Löschen eines Default-Werts und Safe-Area-Abstand ergänzt.

## Prüfung
- Diff gegen `story/63-pat-help` geprüft: nur Quellenformular, Widget-Test und Changelog betroffen.
- Die Tests sind so geschnitten, dass die Validierungsprüfung vor jeglichem Zugriff auf Secure Storage/GitHub endet.
- `flutter analyze`, `dart format` und `flutter test` können über den GitHub-Connector nicht lokal ausgeführt werden und sollten durch CI bzw. lokal vor dem Merge bestätigt werden.

## Dokumentationspflege
- `CHANGELOG.md`: UX-Verbesserungen unter `Unreleased / Changed` dokumentiert.
- `README.md` unverändert, da sich weder Einrichtung noch Nutzungsschritte ändern.
- `docs/architecture.md` unverändert, da Systemgrenzen, Integrationen und Verantwortlichkeiten unverändert bleiben.

## Abhängigkeit
Dieser gestapelte PR basiert auf #67 / Story #63. Vorgesehene Merge-Reihenfolge: #66 → #67 → dieser PR. Nach Merge der jeweiligen Basis kann der PR auf den nächsten Zielbranch bzw. `master` retargetet werden.

Hinweis: Die Story wird bewusst nicht automatisch geschlossen; die manuelle Abnahme und das Schließen des Issues erfolgen separat.