### PR TITLE
Stabilize validation snackbar widget test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ Wenn der Benutzer die Umsetzung einer Story beauftragt, ist grundsätzlich folge
     - `flutter analyze` ausführen und keine neuen Fehler oder Warnungen hinterlassen.
     - Geeignete Unit-, Widget- oder Integrationstests ergänzen bzw. ausführen, soweit dies für die Story sinnvoll ist.
     - Fachliche Logik möglichst durch Unit Tests, relevante UI-Verhalten durch Widget Tests und wichtige Integrationspfade durch geeignete Integrationstests absichern.
+    - Tests nicht durch beliebige feste Wartezeiten synchronisieren. Wenn möglich auf das Erscheinen oder Verschwinden des erwarteten Zustands bzw. Widgets warten. Feste Zeitwerte nur als begrenzendes Timeout oder als kleine Polling-Schritte verwenden, nicht als eigentliche Erfolgsbedingung des Tests.
     - Die Dokumentationspflichten aus dem Abschnitt `Dokumentationspflege bei Änderungen` prüfen und erfüllen.
 
 9. Einen Pull Request erstellen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 ### Changed
 
 - README nach der Struktur von Standard Readme neu gegliedert und mit der weiterführenden Dokumentation verknüpft.
-- Quellenformular ergonomischer gestaltet: zusätzlicher Abstand unter dem Speichern-Button, temporärer Validierungshinweis und Löschaktionen für befüllte Eingabefelder.
+- Quellenformular für kleine Displays verbessert: zusätzlicher Abstand unter `Quelle speichern`, temporärer Validierungshinweis und Löschaktionen für befüllte Felder.
+
+### Fixed
+
+- Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 ### Changed
 
 - README nach der Struktur von Standard Readme neu gegliedert und mit der weiterführenden Dokumentation verknüpft.
-- Quellenformular für kleine Displays verbessert: zusätzlicher Abstand unter `Quelle speichern`, temporärer Validierungshinweis und Löschaktionen für befüllte Felder.
+- Quellenformular ergonomischer gestaltet: zusätzlicher Abstand unter dem Speichern-Button, temporärer Validierungshinweis und Löschaktionen für befüllte Eingabefelder.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Für den Zugriff auf GitHub wird ein **Fine-grained personal access token** verw
 - `Issues`: Read and write
 - `Metadata`: Read-only
 
-Zusätzliche Account Permissions sind für den aktuellen Funktionsumfang nicht erforderlich. Das Token ausschließlich in den App-Einstellungen eingeben und niemals in Quellcode, Screenshots, Issues oder Logs ablegen. Die App speichert es über den geschützten lokalen Plattform-Speicher. Direkt am PAT-Feld kann eine Hilfe mit den benötigten Berechtigungen und den GitHub-Schritten zur Token-Erstellung geöffnet werden.
+Zusätzliche Account Permissions sind für den aktuellen Funktionsumfang nicht erforderlich. Das Token ausschließlich in den App-Einstellungen eingeben und niemals in Quellcode, Screenshots, Issues oder Logs ablegen. Die App speichert es über den geschützten lokalen Plattform-Speicher. Direkt am PAT-Feld kann über das Hilfe-Symbol eine Schritt-für-Schritt-Anleitung zur Erstellung und Berechtigung des Tokens geöffnet werden.
 
 Release-Keystores und daraus erzeugte Base64-Dateien dürfen ebenfalls nicht ins Repository eingecheckt werden.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Für den Zugriff auf GitHub wird ein **Fine-grained personal access token** verw
 - `Issues`: Read and write
 - `Metadata`: Read-only
 
-Zusätzliche Account Permissions sind für den aktuellen Funktionsumfang nicht erforderlich. Das Token ausschließlich in den App-Einstellungen eingeben und niemals in Quellcode, Screenshots, Issues oder Logs ablegen. Die App speichert es über den geschützten lokalen Plattform-Speicher. Direkt am PAT-Feld kann über das Hilfe-Symbol eine Schritt-für-Schritt-Anleitung zur Erstellung und Berechtigung des Tokens geöffnet werden.
+Zusätzliche Account Permissions sind für den aktuellen Funktionsumfang nicht erforderlich. Das Token ausschließlich in den App-Einstellungen eingeben und niemals in Quellcode, Screenshots, Issues oder Logs ablegen. Die App speichert es über den geschützten lokalen Plattform-Speicher. Direkt am PAT-Feld kann eine Hilfe mit den benötigten Berechtigungen und den GitHub-Schritten zur Token-Erstellung geöffnet werden.
 
 Release-Keystores und daraus erzeugte Base64-Dateien dürfen ebenfalls nicht ins Repository eingecheckt werden.
 

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -17,7 +17,7 @@ void main() {
       scrollable: find.byType(Scrollable).first,
     );
     await tester.tap(find.text('Quelle speichern'));
-    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Bitte markierte Pflichtfelder prüfen.'), findsOneWidget);
     expect(find.text('Pflichtfeld'), findsWidgets);

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -3,6 +3,23 @@ import 'package:developer_wiki_source_capture/screens/source_form_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+Future<void> pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 2),
+  Duration step = const Duration(milliseconds: 20),
+}) async {
+  var elapsed = Duration.zero;
+
+  while (finder.evaluate().isEmpty) {
+    if (elapsed >= timeout) {
+      throw TestFailure('Widget wurde innerhalb von $timeout nicht gefunden.');
+    }
+    await tester.pump(step);
+    elapsed += step;
+  }
+}
+
 void main() {
   testWidgets('shows a temporary hint when validation fails', (tester) async {
     await tester.pumpWidget(
@@ -17,9 +34,11 @@ void main() {
       scrollable: find.byType(Scrollable).first,
     );
     await tester.tap(find.text('Quelle speichern'));
-    await tester.pump(const Duration(milliseconds: 300));
 
-    expect(find.text('Bitte markierte Pflichtfelder prüfen.'), findsOneWidget);
+    final validationHint = find.text('Bitte markierte Pflichtfelder prüfen.');
+    await pumpUntilFound(tester, validationHint);
+
+    expect(validationHint, findsOneWidget);
     expect(find.text('Pflichtfeld'), findsWidgets);
   });
 


### PR DESCRIPTION
Implements #69

## Ursache
Der Widget-Test für den Validierungshinweis prüfte den Snackbar-Text zu früh. Ein einzelner `tester.pump()` ist bei der animierten Snackbar kein robuster Synchronisationspunkt; eine beliebig gewählte feste Verzögerung wäre ebenfalls unnötig fragil.

## Lösung
- Der Test verwendet jetzt `pumpUntilFound(...)` und wartet gezielt darauf, dass der erwartete Snackbar-Text tatsächlich im Widget-Baum erscheint.
- Der Helper pumpt nur in kleinen Schritten weiter und bricht mit einem begrenzenden Timeout ab. Die feste Zeit ist damit nicht mehr die Erfolgsbedingung des Tests.
- Die Produktionslogik bleibt unverändert.
- `AGENTS.md` enthält nun die verbindliche Regel, Tests möglichst auf Existenz bzw. Absenz erwarteter Zustände oder Widgets zu synchronisieren und beliebige feste Wartezeiten zu vermeiden.

## Prüfung
- Diff gegen `master` geprüft: betroffen sind nur `test/source_form_screen_test.dart`, `AGENTS.md` und der maintainerrelevante Changelog-Eintrag.
- Keine Änderung am Nutzerverhalten oder an fachlicher Logik.
- Bitte lokal `flutter test` erneut ausführen; der GitHub-Connector kann die Flutter-Tests nicht selbst starten.

## Dokumentationspflege
- `AGENTS.md`: Regel für zustandsbasierte Testsynchronisation ergänzt.
- `CHANGELOG.md`: Teststabilisierung unter `Unreleased / Fixed` dokumentiert.
- `README.md` und `docs/` unverändert, da weder Nutzung noch Architektur betroffen sind.

Hinweis: Issue #69 wird bewusst nicht automatisch geschlossen; die manuelle Abnahme erfolgt separat.