### PR TITLE
Target save button directly in snackbar widget test

### DIFF
--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -28,12 +28,9 @@ void main() {
       ),
     );
 
-    await tester.scrollUntilVisible(
-      find.text('Quelle speichern'),
-      300,
-      scrollable: find.byType(Scrollable).first,
-    );
-    await tester.tap(find.text('Quelle speichern'));
+    final saveButton = find.widgetWithText(FilledButton, 'Quelle speichern');
+    await tester.ensureVisible(saveButton);
+    await tester.tap(saveButton);
 
     final validationHint = find.text('Bitte markierte Pflichtfelder prüfen.');
     await pumpUntilFound(tester, validationHint);


### PR DESCRIPTION
Closes #72

## Ursache
Der Test wartete nach dem Tap korrekt zustandsbasiert auf die Validierungs-Snackbar, adressierte zum Scrollen und Tippen aber nur das innere Text-Widget `Quelle speichern`. In dem scrollbaren Formular war damit nicht zuverlässig sichergestellt, dass die eigentliche `FilledButton`-Aktion ausgelöst wird. Der Timeout war daher nur das Symptom; die Snackbar wurde gar nicht erzeugt.

## Lösung
- Speichern-Aktion im Test über `find.widgetWithText(FilledButton, 'Quelle speichern')` adressiert.
- Das tatsächliche Button-Widget vor dem Tap mit `tester.ensureVisible(...)` sichtbar gemacht.
- Zustandsbasiertes `pumpUntilFound(...)` unverändert beibehalten.
- Keine feste Wartezeit und keine Änderung an Produktionscode oder Nutzerverhalten.

## Prüfung
- Diff gegen `master`: ausschließlich `test/source_form_screen_test.dart` geändert.
- Der Branch ist genau einen Commit vor `master` und nicht dahinter.
- Bitte lokal `flutter test` ausführen; die Flutter-Toolchain kann über den GitHub-Connector nicht ausgeführt werden.

## Dokumentationspflege
`CHANGELOG.md`, `README.md` und `docs/` bleiben unverändert. Die bestehende Changelog-Zeile dokumentiert bereits die zustandsbasierte Stabilisierung dieses Tests; dieser Folgefix korrigiert ausschließlich das Interaktionsziel im Test und ändert weder Nutzerverhalten noch Architektur.