### PR TITLE
Use stable key for save button widget test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 ### Fixed
 
 - Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
+- Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -237,6 +237,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             ...template.fields.map(_field),
             const SizedBox(height: 20),
             FilledButton.icon(
+              key: const Key('source-form-save-button'),
               onPressed: busy ? null : submit,
               icon: const Icon(Icons.cloud_upload),
               label: Text(busy ? 'Wird erstellt …' : 'Quelle speichern'),

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -28,7 +28,7 @@ void main() {
       ),
     );
 
-    final saveButton = find.widgetWithText(FilledButton, 'Quelle speichern');
+    final saveButton = find.byKey(const Key('source-form-save-button'));
     await tester.ensureVisible(saveButton);
     await tester.tap(saveButton);
 


### PR DESCRIPTION
Closes #78

## Ursache
Der Test suchte den Speichern-Button über `find.widgetWithText(FilledButton, 'Quelle speichern')`. Der Screen rendert den Button jedoch über `FilledButton.icon(...)`. Dadurch lieferte der Finder auf `master` kein Element und `tester.ensureVisible(...)` brach bereits vor der eigentlichen Validierungs- und Snackbar-Logik mit `Bad state: No element` ab.

## Lösung
- Dem Speichern-Button einen stabilen Key `source-form-save-button` gegeben.
- Den Widget-Test auf `find.byKey(const Key('source-form-save-button'))` umgestellt.
- Zustandsbasiertes Warten auf die Validierungs-Snackbar beibehalten.
- Keine festen Wartezeiten eingeführt.
- Nutzerverhalten unverändert gelassen.

## Prüfung
- Branch basiert direkt auf aktuellem `master` und ist nicht dahinter.
- Diff enthält nur den stabilen Key, die Testumstellung und einen Changelog-Eintrag.
- Bitte lokal `flutter test` ausführen; die Flutter-Toolchain kann über den GitHub-Connector nicht ausgeführt werden.

## Dokumentationspflege
`CHANGELOG.md` unter `Unreleased / Fixed` ergänzt. README und `docs/` sind nicht betroffen, da weder Nutzerverhalten noch Architektur geändert werden.