### PR TITLE
Scroll to lazily built save button in widget test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 - Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
 - Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
+- Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -29,7 +29,11 @@ void main() {
     );
 
     final saveButton = find.byKey(const Key('source-form-save-button'));
-    await tester.ensureVisible(saveButton);
+    await tester.scrollUntilVisible(
+      saveButton,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
     await tester.tap(saveButton);
 
     final validationHint = find.text('Bitte markierte Pflichtfelder prüfen.');


### PR DESCRIPTION
Closes #81

## Ursache
Der Speichern-Button liegt am Ende eines `ListView`. Außerhalb des sichtbaren Bereichs liegende Listenelemente sind im Widget-Test nicht zwingend bereits gebaut. Dadurch liefert `find.byKey(const Key('source-form-save-button'))` zunächst kein Element und `tester.ensureVisible(saveButton)` scheitert mit `Bad state: No element`.

## Lösung
- `ensureVisible(saveButton)` durch `scrollUntilVisible(...)` ersetzt.
- Der Test scrollt nun gezielt im ersten `Scrollable`, bis der per Key adressierte Speichern-Button tatsächlich im Widget-Baum existiert.
- Anschließend wird der Button wie bisher angetippt.
- Das zustandsbasierte Warten auf die Validierungs-Snackbar bleibt unverändert.
- Keine feste Wartezeit als Erfolgsbedingung eingeführt.

## Prüfung
- Branch basiert direkt auf aktuellem `master` und ist nicht dahinter.
- Diff enthält nur die Testkorrektur und einen Changelog-Eintrag.
- Bitte lokal `flutter test` ausführen; die Flutter-Toolchain kann über den GitHub-Connector nicht ausgeführt werden.

## Dokumentationspflege
`CHANGELOG.md` unter `Unreleased / Fixed` ergänzt. README und `docs/` sind nicht betroffen, da weder Nutzerverhalten noch Architektur geändert werden.