### PR TITLE
Stabilize save button tap after scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 - Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
 - Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
 - Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
+- Widget-Test stabilisiert nach dem Scrollen die Sichtbarkeit und das Layout des Speichern-Buttons vor dem Tap.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -34,6 +34,8 @@ void main() {
       300,
       scrollable: find.byType(Scrollable).first,
     );
+    await tester.ensureVisible(saveButton);
+    await tester.pump();
     await tester.tap(saveButton);
 
     final validationHint = find.text('Bitte markierte Pflichtfelder prüfen.');


### PR DESCRIPTION
Closes #83

## Ursache
Der Test findet den lazily aufgebauten Speichern-Button inzwischen korrekt über `scrollUntilVisible(...)`, stabilisiert danach aber weder die endgültige Sichtbarkeit noch den verarbeiteten Layoutzustand, bevor unmittelbar getappt wird. Dadurch kann die `onPressed`-Aktion im Widget-Test ausbleiben und die erwartete Validierungs-Snackbar erscheint nicht.

## Lösung
- `scrollUntilVisible(...)` bleibt bestehen, damit der Button überhaupt gebaut wird.
- Danach wird `ensureVisible(saveButton)` verwendet, jetzt auf einem tatsächlich existierenden Widget.
- Ein normales `tester.pump()` verarbeitet den endgültigen Scroll-/Layoutzustand.
- Erst anschließend wird der Button getappt.
- Das zustandsbasierte Warten auf die Snackbar bleibt unverändert; keine feste Zeitverzögerung als Erfolgsbedingung.

## Prüfung
- Branch basiert direkt auf aktuellem `master` und ist nicht dahinter.
- Diff enthält nur zwei zusätzliche Testschritte und einen Changelog-Eintrag.
- Bitte lokal `flutter test test/source_form_screen_test.dart` und danach `flutter test` ausführen; die Flutter-Toolchain kann über den GitHub-Connector nicht ausgeführt werden.

## Dokumentationspflege
`CHANGELOG.md` unter `Unreleased / Fixed` ergänzt. README und `docs/` sind nicht betroffen, da weder Nutzerverhalten noch Architektur geändert werden.