### PR TITLE
Validate required source fields independently of scroll position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 - Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
 - Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
 - Widget-Test stabilisiert nach dem Scrollen die Sichtbarkeit und das Layout des Speichern-Buttons vor dem Tap.
+- Pflichtfelder werden beim Speichern unabhängig von ihrer aktuellen Sichtbarkeit im scrollbaren Quellenformular geprüft.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -66,7 +66,8 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   }
 
   Future<void> submit() async {
-    if (!key.currentState!.validate()) {
+    final formIsValid = key.currentState?.validate() ?? false;
+    if (!formIsValid || _hasMissingRequiredValues()) {
       _showValidationHint();
       return;
     }
@@ -101,6 +102,15 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
         setState(() => busy = false);
       }
     }
+  }
+
+  bool _hasMissingRequiredValues() {
+    if (title.text.trim().isEmpty) {
+      return true;
+    }
+    return template.fields.any(
+      (field) => field.required && values[field.id]!.text.trim().isEmpty,
+    );
   }
 
   void _showValidationHint() {


### PR DESCRIPTION
Closes #85

## Ursache
Die vorherigen Testfixes haben den Speichern-Button inzwischen zuverlässig gefunden und angetippt. Der eigentliche Fehler liegt jedoch in der Produktionslogik: Das Formular wird in einem lazily aufgebauten `ListView` gerendert. Beim Scrollen zum unteren Speichern-Button können Pflichtfelder am Anfang des Formulars bereits aus dem Widget-Baum entfernt und damit nicht mehr im `FormState` registriert sein. `FormState.validate()` kann dann fälschlich erfolgreich sein, obwohl Pflichtwerte fehlen.

## Lösung
- Vor dem Submit werden Pflichtwerte zusätzlich direkt anhand der Controller und der aktuellen `SourceTemplate`-Definition geprüft.
- `Issue-Titel` und alle `required`-Felder werden damit unabhängig von aktueller Scrollposition bzw. Mount-Zustand validiert.
- Die bestehende `FormState.validate()`-Prüfung bleibt erhalten, damit sichtbare Felder weiterhin ihre Feldfehler anzeigen.
- Bei fehlenden Pflichtwerten wird wie vorgesehen die Snackbar `Bitte markierte Pflichtfelder prüfen.` angezeigt.
- Keine festen Wartezeiten eingeführt.

## Prüfung
- Branch basiert direkt auf aktuellem `master` und ist nicht dahinter.
- Diff betrifft nur `lib/screens/source_form_screen.dart` und `CHANGELOG.md`.
- Bitte lokal zuerst `flutter test test/source_form_screen_test.dart` und danach `flutter test` ausführen.
- Zusätzlich sollte manuell geprüft werden, dass ein unvollständiges Formular auch nach Scrollen bis zum Speichern-Button nicht abgeschickt wird.

## Dokumentationspflege
`CHANGELOG.md` unter `Unreleased / Fixed` ergänzt. README und `docs/` sind nicht betroffen, da weder Bedienkonzept noch Architektur geändert werden.