### PR TITLE
Align snackbar widget test with global validation hint behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,5 +28,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 - Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
 - Widget-Test stabilisiert nach dem Scrollen die Sichtbarkeit und das Layout des Speichern-Buttons vor dem Tap.
 - Pflichtfelder werden beim Speichern unabhängig von ihrer aktuellen Sichtbarkeit im scrollbaren Quellenformular geprüft.
+- Snackbar-Widget-Test prüft nur den globalen Validierungshinweis und setzt keine gleichzeitig sichtbaren Inline-Feldfehler voraus.
 
 [Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -42,7 +42,6 @@ void main() {
     await pumpUntilFound(tester, validationHint);
 
     expect(validationHint, findsOneWidget);
-    expect(find.text('Pflichtfeld'), findsWidgets);
   });
 
   testWidgets('clears a default value with one tap', (tester) async {


### PR DESCRIPTION
Closes #87

## Ursache
Der Snackbar-Test war inzwischen funktional bis zum eigentlichen Ziel gekommen: Die Snackbar `Bitte markierte Pflichtfelder prüfen.` erscheint und wird gefunden. Anschließend erwartete der Test zusätzlich sichtbare `Pflichtfeld`-Texte. Nach dem Scrollen bis zum Speichern-Button sind die oberen Pflichtfelder im lazily aufgebauten `ListView` jedoch nicht zwingend gleichzeitig gemountet, daher ist diese Zusatzannahme nicht zuverlässig.

## Lösung
- Die fachlich überflüssige Erwartung `expect(find.text('Pflichtfeld'), findsWidgets)` aus diesem Test entfernt.
- Der Test prüft nun genau sein benanntes Verhalten: den temporären globalen Validierungshinweis beim Speichern eines unvollständigen Formulars.
- Zustandsbasiertes Warten auf die Snackbar bleibt erhalten.
- Keine festen Wartezeiten eingeführt.

## Prüfung
- Branch basiert auf aktuellem `master` und ist nicht dahinter.
- Diff enthält nur eine entfernte Testerwartung und einen Changelog-Eintrag.
- Bitte lokal `flutter test test/source_form_screen_test.dart` und anschließend `flutter test` ausführen.

## Dokumentationspflege
`CHANGELOG.md` unter `Unreleased / Fixed` ergänzt. README und `docs/` sind nicht betroffen, da sich kein Nutzerverhalten und keine Architektur ändern.