### PR TITLE
chore: Release 0.1.0+2 vorbereiten

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: developer_wiki_source_capture
 description: Android-App zur strukturierten Erfassung von Quellen-Issues im Developer-Wiki.
 publish_to: none
-version: 0.1.0+1
+version: 0.1.0+2
 environment:
   sdk: '>=3.4.0 <4.0.0'
 dependencies:


### PR DESCRIPTION
## Änderung

- erhöht die Flutter-Paketversion in `pubspec.yaml` von `0.1.0+1` auf `0.1.0+2`
- bereitet damit den nächsten Android-Release-Build gemäß der Release-Dokumentation vor

## Prüfung

- Versionsformat `MAJOR.MINOR.PATCH+BUILD` geprüft
- Branch-Inhalt erneut über GitHub verifiziert
- keine Laufzeittests ausgeführt, da ausschließlich die deklarative Buildnummer geändert wurde

## Dokumentation und Lizenzen

- `CHANGELOG.md`, `README.md` und `docs/` benötigen keine Anpassung, da sich weder Funktionsumfang noch Release-Ablauf ändern
- keine Komponenten oder Assets aufgenommen; `ATTRIBUTIONS.md` und die MIT-Lizenz bleiben unverändert