### PR TITLE
Bildquellenmodell, Bildauswahl und Vorschau bereitstellen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Added
 
+- Grundlage für Bild-Quellen mit eigenem Quellentyp, validierter Bildauswahl,
+  Vorschau sowie Entfernen und Ersetzen des unveränderten Originalbilds.
 - Verbindliche Projektdokumentation unter `docs/` mit C4-orientierter Architekturübersicht.
 - Dokumentationsregeln für Changelog, README und technische Dokumentation im Implementierungsworkflow.
 - Direkt in den Einstellungen aufrufbare Hilfe zum Erstellen eines Fine-grained GitHub PAT mit den benötigten Least-Privilege-Berechtigungen.

--- a/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
@@ -1,19 +1,56 @@
 package de.huluvu.developer_wiki_source_capture
 
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.provider.OpenableColumns
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
 
 class MainActivity : FlutterActivity() {
+    private companion object {
+        const val IMAGE_PICK_REQUEST = 4201
+        const val MAX_IMAGE_BYTES = 10L * 1024L * 1024L
+        val SUPPORTED_IMAGE_TYPES = setOf("image/png", "image/gif", "image/jpeg")
+    }
+
     private var shareChannel: MethodChannel? = null
     private var pendingShare: Map<String, String>? = null
+    private var imagePickerResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         configureExternalUrlChannel(flutterEngine)
         configureShareChannel(flutterEngine)
+        configureImageChannel(flutterEngine)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != IMAGE_PICK_REQUEST) {
+            return
+        }
+
+        val result = imagePickerResult
+        imagePickerResult = null
+        if (result == null) {
+            return
+        }
+        val uri = data?.data
+        if (resultCode != Activity.RESULT_OK || uri == null) {
+            result.success(null)
+            return
+        }
+
+        try {
+            result.success(copyImageToPrivateCache(uri))
+        } catch (error: Exception) {
+            result.error("image_copy_failed", error.message, null)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -68,6 +105,136 @@ class MainActivity : FlutterActivity() {
                 pendingShare = null
                 result.success(content)
             }
+        }
+    }
+
+    private fun configureImageChannel(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "developer_wiki/image"
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "pickImage" -> openImagePicker(result)
+                "discardImage" -> {
+                    val path = call.argument<String>("path")
+                    if (path.isNullOrBlank()) {
+                        result.error("invalid_path", "Bildpfad fehlt.", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        discardCachedImage(path)
+                        result.success(null)
+                    } catch (error: Exception) {
+                        result.error("discard_failed", error.message, null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun openImagePicker(result: MethodChannel.Result) {
+        if (imagePickerResult != null) {
+            result.error("picker_busy", "Die Bildauswahl ist bereits geöffnet.", null)
+            return
+        }
+        imagePickerResult = result
+        val picker = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "image/*"
+            putExtra(
+                Intent.EXTRA_MIME_TYPES,
+                arrayOf("image/png", "image/gif", "image/jpeg")
+            )
+        }
+        try {
+            startActivityForResult(picker, IMAGE_PICK_REQUEST)
+        } catch (error: Exception) {
+            imagePickerResult = null
+            result.error("picker_failed", error.message, null)
+        }
+    }
+
+    private fun copyImageToPrivateCache(uri: Uri): Map<String, Any> {
+        val mimeType = contentResolver.getType(uri)?.lowercase()
+            ?: throw IllegalArgumentException("Der Bildtyp konnte nicht ermittelt werden.")
+        if (mimeType !in SUPPORTED_IMAGE_TYPES) {
+            throw IllegalArgumentException("Unterstützt werden PNG-, GIF- und JPEG-Bilder.")
+        }
+
+        val displayName = displayName(uri)
+        val safeName = displayName
+            .replace(Regex("[^A-Za-z0-9._-]"), "_")
+            .takeLast(100)
+            .ifBlank { "image" }
+        val directory = File(cacheDir, "image_sources").apply { mkdirs() }
+        val target = File(directory, "${UUID.randomUUID()}-$safeName")
+        var total = 0L
+
+        try {
+            contentResolver.openInputStream(uri).use { input ->
+                requireNotNull(input) { "Das Bild konnte nicht geöffnet werden." }
+                FileOutputStream(target).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) {
+                            break
+                        }
+                        total += read
+                        if (total > MAX_IMAGE_BYTES) {
+                            throw IllegalArgumentException(
+                                "Das Bild darf höchstens 10 MiB groß sein."
+                            )
+                        }
+                        output.write(buffer, 0, read)
+                    }
+                }
+            }
+        } catch (error: Exception) {
+            target.delete()
+            throw error
+        }
+
+        if (total == 0L) {
+            target.delete()
+            throw IllegalArgumentException("Die ausgewählte Bilddatei ist leer.")
+        }
+        return mapOf(
+            "path" to target.absolutePath,
+            "name" to displayName,
+            "mimeType" to mimeType,
+            "sizeBytes" to total
+        )
+    }
+
+    private fun displayName(uri: Uri): String {
+        contentResolver.query(
+            uri,
+            arrayOf(OpenableColumns.DISPLAY_NAME),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0) {
+                    return cursor.getString(index) ?: "image"
+                }
+            }
+        }
+        return uri.lastPathSegment ?: "image"
+    }
+
+    private fun discardCachedImage(path: String) {
+        val directory = File(cacheDir, "image_sources").canonicalFile
+        val image = File(path).canonicalFile
+        val allowedPrefix = directory.path + File.separator
+        require(image.path.startsWith(allowedPrefix)) {
+            "Nur temporäre Bilddateien der App dürfen entfernt werden."
+        }
+        if (image.exists() && !image.delete()) {
+            throw IllegalStateException("Die temporäre Bilddatei konnte nicht entfernt werden.")
         }
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,8 @@ flowchart TB
 
     subgraph app["Software System: Developer-Wiki-App"]
         ui["Container\nFlutter UI\nScreens, Formulare, Navigation"]
-        services["Container\nAnwendungsservices\nGitHub-, Konfigurations-, Prefill- und URL-Services"]
-        storage["Container\nLokaler geschützter Speicher\nKonfiguration und Fine-grained PAT"]
+        services["Container\nAnwendungsservices\nGitHub-, Konfigurations-, Bild-, Prefill- und URL-Services"]
+        storage["Container\nLokaler Speicher\nGeschützte Konfiguration, PAT und temporäre Bilder"]
     end
 
     github["External Software System\nGitHub REST API\nIssues, Repository-Metadaten, Actions"]
@@ -53,6 +53,9 @@ flowchart TB
 - GitHub-API-Aufrufe werden zentral über Services gekapselt; Screens bauen keine HTTP-Requests selbst zusammen.
 - Das Fine-grained PAT wird lokal über den geschützten Plattform-Speicher abgelegt und nicht geloggt oder im Repository gespeichert.
 - Unterschiedliche Einstiegspunkte, etwa normale Erfassung und Android Share, verwenden denselben fachlichen Erfassungsweg.
+- Bilddateien werden über eine gekapselte Plattformabstraktion ausgewählt,
+  anhand von Dateityp, Größe und Signatur validiert und nur unverändert im
+  privaten temporären App-Speicher gehalten.
 - Konfigurierbare Werte wie Ziel-Repository und Workflow-Datei werden nicht unnötig im UI-Code fest verdrahtet.
 - Die Architektur bleibt mobile-first, testbar und so einfach wie für den aktuellen Funktionsumfang möglich.
 

--- a/lib/models/image_source_file.dart
+++ b/lib/models/image_source_file.dart
@@ -1,0 +1,20 @@
+class ImageSourceFile {
+  const ImageSourceFile({
+    required this.path,
+    required this.name,
+    required this.mimeType,
+    required this.sizeBytes,
+  });
+
+  final String path;
+  final String name;
+  final String mimeType;
+  final int sizeBytes;
+
+  String get formattedSize {
+    if (sizeBytes >= 1024 * 1024) {
+      return '${(sizeBytes / (1024 * 1024)).toStringAsFixed(1)} MiB';
+    }
+    return '${(sizeBytes / 1024).toStringAsFixed(1)} KiB';
+  }
+}

--- a/lib/models/source_template.dart
+++ b/lib/models/source_template.dart
@@ -1,4 +1,4 @@
-enum FieldKind { input, textarea, dropdown }
+enum FieldKind { input, textarea, dropdown, image }
 
 class SourceField {
   const SourceField(
@@ -28,6 +28,38 @@ class SourceTemplate {
 
 const agentInstruction =
     'Halte dich bei der Bearbeitung an alle für die betroffenen Dateien geltenden Anweisungen aus der AGENTS.md.';
+
+const imageSourceTemplate = SourceTemplate(
+  name: '🖼️ Bild-Quelle',
+  titlePrefix: '[Bild-Quelle]: ',
+  description:
+      'Ein Bild oder einen Screenshot als eigenständige Originalquelle erfassen.',
+  fields: [
+    SourceField(
+      id: 'content',
+      label: 'Inhalt',
+      kind: FieldKind.image,
+      required: true,
+      description: 'PNG, GIF oder JPEG · maximal 10 MiB',
+    ),
+    SourceField(
+      id: 'description',
+      label: 'Beschreibung',
+      kind: FieldKind.textarea,
+    ),
+    SourceField(
+      id: 'agent_notes',
+      label: 'Hinweise an den KI-Agenten',
+      kind: FieldKind.textarea,
+    ),
+    SourceField(
+      id: 'prompt_additions',
+      label: 'Promptergänzungen',
+      kind: FieldKind.textarea,
+      initialValue: agentInstruction,
+    ),
+  ],
+);
 
 const sourceTemplates = <SourceTemplate>[
   SourceTemplate(
@@ -225,4 +257,5 @@ const sourceTemplates = <SourceTemplate>[
             initialValue:
                 'Behandle die beschriebene Person als Privatperson. Recherchiere weder zu ihr noch zu den gemachten Angaben im Internet und rufe keine externen Quellen zur Ergänzung oder Bestätigung ab. Verwende ausschließlich den fachlichen Inhalt dieser privaten Quelle. Falls im Wiki eine öffentliche Quelle zur selben Person existiert, verknüpfe beide Datensätze gegenseitig, halte private und öffentlich belegte Informationen jedoch in getrennten Wiki-Datensätzen und übernimm keine Aussagen zwischen ihnen.'),
       ]),
+  imageSourceTemplate,
 ];

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -1,12 +1,17 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../models/created_issue.dart';
+import '../models/image_source_file.dart';
 import '../models/shared_content.dart';
 import '../models/source_template.dart';
 import '../models/wiki_configuration.dart';
 import '../services/configuration_service.dart';
 import '../services/external_url_service.dart';
 import '../services/github_service.dart';
+import '../services/image_input_service.dart';
 import '../services/source_prefill_service.dart';
 import 'settings_screen.dart';
 
@@ -15,10 +20,12 @@ class SourceFormScreen extends StatefulWidget {
     super.key,
     this.initialTemplate,
     this.sharedContent,
+    this.imageInputGateway,
   });
 
   final SourceTemplate? initialTemplate;
   final SharedContent? sharedContent;
+  final ImageInputGateway? imageInputGateway;
 
   @override
   State<SourceFormScreen> createState() => _SourceFormScreenState();
@@ -32,27 +39,40 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   final _configurationService = ConfigurationService();
   final _externalUrlService = ExternalUrlService();
   final _prefillService = SourcePrefillService();
+  late final ImageInputGateway _imageInputGateway;
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
+  bool _imageBusy = false;
   bool _useSharedContent = true;
   CreatedIssue? _createdIssue;
+  ImageSourceFile? _image;
+  bool _imagePrepared = false;
   String? _errorMessage;
 
   @override
   void initState() {
     super.initState();
+    _imageInputGateway =
+        widget.imageInputGateway ?? PlatformImageInputGateway();
     _select(widget.initialTemplate ?? sourceTemplates.first);
   }
 
   void _select(SourceTemplate next) {
+    final previousImage = _image;
+    if (previousImage != null) {
+      unawaited(_imageInputGateway.discard(previousImage));
+      _image = null;
+    }
     template = next;
     for (final controller in values.values) {
       controller.dispose();
     }
     values.clear();
     for (final field in next.fields) {
-      values[field.id] = TextEditingController(text: field.initialValue);
+      if (field.kind != FieldKind.image) {
+        values[field.id] = TextEditingController(text: field.initialValue);
+      }
     }
     final sharedContent = widget.sharedContent;
     if (_useSharedContent && sharedContent != null) {
@@ -62,6 +82,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       }
     }
     _createdIssue = null;
+    _imagePrepared = false;
     _errorMessage = null;
   }
 
@@ -76,6 +97,13 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       busy = true;
       _errorMessage = null;
     });
+    if (template == imageSourceTemplate) {
+      setState(() {
+        busy = false;
+        _imagePrepared = true;
+      });
+      return;
+    }
     try {
       final configuration = await _configurationService.load();
       final repository = _repositoryFrom(configuration);
@@ -109,8 +137,63 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       return true;
     }
     return template.fields.any(
-      (field) => field.required && values[field.id]!.text.trim().isEmpty,
+      (field) =>
+          field.required &&
+          (field.kind == FieldKind.image
+              ? _image == null
+              : values[field.id]!.text.trim().isEmpty),
     );
+  }
+
+  Future<void> _pickImage() async {
+    setState(() {
+      _imageBusy = true;
+      _errorMessage = null;
+      _imagePrepared = false;
+    });
+    try {
+      final selected = await _imageInputGateway.pickImage();
+      if (selected == null || !mounted) {
+        return;
+      }
+      final previous = _image;
+      setState(() => _image = selected);
+      if (previous != null) {
+        await _imageInputGateway.discard(previous);
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(
+          () => _errorMessage =
+              'Bild konnte nicht übernommen werden: $error',
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _imageBusy = false);
+      }
+    }
+  }
+
+  Future<void> _removeImage() async {
+    final image = _image;
+    if (image == null) {
+      return;
+    }
+    setState(() {
+      _image = null;
+      _imagePrepared = false;
+    });
+    try {
+      await _imageInputGateway.discard(image);
+    } catch (error) {
+      if (mounted) {
+        setState(
+          () => _errorMessage =
+              'Temporäre Bilddatei konnte nicht entfernt werden: $error',
+        );
+      }
+    }
   }
 
   void _showValidationHint() {
@@ -154,16 +237,28 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     _useSharedContent = false;
     title.clear();
     for (final field in template.fields) {
-      values[field.id]!.text = field.initialValue;
+      if (field.kind != FieldKind.image) {
+        values[field.id]!.text = field.initialValue;
+      }
+    }
+    final image = _image;
+    if (image != null) {
+      unawaited(_imageInputGateway.discard(image));
+      _image = null;
     }
     setState(() {
       _createdIssue = null;
+      _imagePrepared = false;
       _errorMessage = null;
     });
   }
 
   @override
   void dispose() {
+    final image = _image;
+    if (image != null) {
+      unawaited(_imageInputGateway.discard(image));
+    }
     title.dispose();
     for (final controller in values.values) {
       controller.dispose();
@@ -228,6 +323,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               child: Text(template.description),
             ),
             if (_createdIssue != null) _successCard(_createdIssue!),
+            if (_imagePrepared) _preparedImageCard(),
             if (_errorMessage != null) _errorCard(_errorMessage!),
             ValueListenableBuilder<TextEditingValue>(
               valueListenable: title,
@@ -250,7 +346,13 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               key: const Key('source-form-save-button'),
               onPressed: busy ? null : submit,
               icon: const Icon(Icons.cloud_upload),
-              label: Text(busy ? 'Wird erstellt …' : 'Quelle speichern'),
+              label: Text(
+                busy
+                    ? 'Wird erstellt …'
+                    : template == imageSourceTemplate
+                        ? 'Bildquelle vorbereiten'
+                        : 'Quelle speichern',
+              ),
             ),
             SizedBox(
               key: const Key('source-form-bottom-clearance'),
@@ -328,6 +430,9 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   }
 
   Widget _field(SourceField field) {
+    if (field.kind == FieldKind.image) {
+      return _imageField(field);
+    }
     final controller = values[field.id]!;
     if (field.kind == FieldKind.dropdown) {
       return Padding(
@@ -382,6 +487,114 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
           validator: (value) => field.required && (value ?? '').trim().isEmpty
               ? 'Pflichtfeld'
               : null,
+        ),
+      ),
+    );
+  }
+
+  Widget _imageField(SourceField field) {
+    final image = _image;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: FormField<ImageSourceFile>(
+        key: const Key('image-source-field'),
+        initialValue: image,
+        validator: (_) =>
+            field.required && _image == null ? 'Pflichtfeld' : null,
+        builder: (formField) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              field.label,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(field.description),
+            const SizedBox(height: 12),
+            if (image == null)
+              OutlinedButton.icon(
+                key: const Key('image-source-pick-button'),
+                onPressed: _imageBusy || busy ? null : _pickImage,
+                icon: const Icon(Icons.image_outlined),
+                label: Text(
+                  _imageBusy ? 'Bild wird übernommen …' : 'Bild auswählen',
+                ),
+              )
+            else ...[
+              Semantics(
+                label: 'Vorschau des ausgewählten Bildes ${image.name}',
+                image: true,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: SizedBox(
+                    key: const Key('image-source-preview'),
+                    width: double.infinity,
+                    height: 220,
+                    child: Image.file(
+                      File(image.path),
+                      fit: BoxFit.contain,
+                      errorBuilder: (_, __, ___) => const Center(
+                        child: Text('Bildvorschau nicht verfügbar'),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text('${image.name} · ${image.formattedSize}'),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  OutlinedButton.icon(
+                    onPressed: _imageBusy || busy ? null : _pickImage,
+                    icon: const Icon(Icons.swap_horiz),
+                    label: const Text('Ersetzen'),
+                  ),
+                  OutlinedButton.icon(
+                    key: const Key('image-source-remove-button'),
+                    onPressed: _imageBusy || busy ? null : _removeImage,
+                    icon: const Icon(Icons.delete_outline),
+                    label: const Text('Entfernen'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const Card(
+                child: Padding(
+                  padding: EdgeInsets.all(12),
+                  child: Text(
+                    'Hinweis: Fotos können Aufnahmeort, Geräteinformationen '
+                    'und weitere sensible Metadaten enthalten. Das Originalbild '
+                    'wird unverändert übernommen.',
+                  ),
+                ),
+              ),
+            ],
+            if (formField.hasError) ...[
+              const SizedBox(height: 8),
+              Text(
+                formField.errorText!,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _preparedImageCard() {
+    return const Card(
+      margin: EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'Die Bild-Quelle ist lokal vorbereitet. Der GitHub-Attachment-Upload '
+          'wird im abschließenden Teil des gestapelten Ablaufs ergänzt.',
         ),
       ),
     );

--- a/lib/services/image_input_service.dart
+++ b/lib/services/image_input_service.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+
+import '../models/image_source_file.dart';
+import 'image_validation_service.dart';
+
+abstract interface class ImageInputGateway {
+  Future<ImageSourceFile?> pickImage();
+
+  Future<void> discard(ImageSourceFile image);
+}
+
+class PlatformImageInputGateway implements ImageInputGateway {
+  PlatformImageInputGateway({
+    MethodChannel? channel,
+    ImageValidationService? validationService,
+  })  : _channel = channel ?? const MethodChannel('developer_wiki/image'),
+        _validationService = validationService ?? ImageValidationService();
+
+  final MethodChannel _channel;
+  final ImageValidationService _validationService;
+
+  @override
+  Future<ImageSourceFile?> pickImage() async {
+    final value = await _channel.invokeMapMethod<String, dynamic>('pickImage');
+    if (value == null) {
+      return null;
+    }
+    final image = _fromMap(value);
+    return _validationService.validate(image);
+  }
+
+  @override
+  Future<void> discard(ImageSourceFile image) {
+    return _channel.invokeMethod<void>('discardImage', {'path': image.path});
+  }
+
+  ImageSourceFile _fromMap(Map<String, dynamic> value) {
+    final path = value['path']?.toString() ?? '';
+    final name = value['name']?.toString() ?? '';
+    final mimeType = value['mimeType']?.toString() ?? '';
+    final sizeValue = value['sizeBytes'];
+    final sizeBytes = sizeValue is int
+        ? sizeValue
+        : int.tryParse(sizeValue?.toString() ?? '') ?? 0;
+    if (path.isEmpty || name.isEmpty || mimeType.isEmpty) {
+      throw const FormatException('Das ausgewählte Bild ist unvollständig.');
+    }
+    return ImageSourceFile(
+      path: path,
+      name: name,
+      mimeType: mimeType,
+      sizeBytes: sizeBytes,
+    );
+  }
+}

--- a/lib/services/image_validation_service.dart
+++ b/lib/services/image_validation_service.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import '../models/image_source_file.dart';
+
+class ImageValidationService {
+  static const maxBytes = 10 * 1024 * 1024;
+  static const supportedMimeTypes = <String>{
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+  };
+
+  Future<ImageSourceFile> validate(ImageSourceFile image) async {
+    final file = File(image.path);
+    if (!await file.exists()) {
+      throw const FormatException('Die ausgewählte Bilddatei ist nicht mehr verfügbar.');
+    }
+
+    final size = await file.length();
+    if (size <= 0) {
+      throw const FormatException('Die ausgewählte Bilddatei ist leer.');
+    }
+    if (size > maxBytes) {
+      throw const FormatException('Das Bild darf höchstens 10 MiB groß sein.');
+    }
+
+    final mimeType = image.mimeType.toLowerCase();
+    if (!supportedMimeTypes.contains(mimeType)) {
+      throw const FormatException(
+        'Unterstützt werden PNG-, GIF- und JPEG-Bilder.',
+      );
+    }
+
+    final header = await file.openRead(0, 16).fold<List<int>>(
+      <int>[],
+      (bytes, chunk) => bytes..addAll(chunk),
+    );
+    if (!_matchesSignature(mimeType, header)) {
+      throw const FormatException(
+        'Dateityp und tatsächlicher Bildinhalt stimmen nicht überein.',
+      );
+    }
+
+    return ImageSourceFile(
+      path: image.path,
+      name: image.name,
+      mimeType: mimeType,
+      sizeBytes: size,
+    );
+  }
+
+  bool _matchesSignature(String mimeType, List<int> bytes) {
+    return switch (mimeType) {
+      'image/png' => _startsWith(
+          bytes,
+          const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+        ),
+      'image/jpeg' => _startsWith(bytes, const [0xff, 0xd8, 0xff]),
+      'image/gif' =>
+        _startsWith(bytes, 'GIF87a'.codeUnits) ||
+            _startsWith(bytes, 'GIF89a'.codeUnits),
+      _ => false,
+    };
+  }
+
+  bool _startsWith(List<int> bytes, List<int> signature) {
+    if (bytes.length < signature.length) {
+      return false;
+    }
+    for (var index = 0; index < signature.length; index++) {
+      if (bytes[index] != signature[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/test/image_source_template_test.dart
+++ b/test/image_source_template_test.dart
@@ -1,0 +1,19 @@
+import 'package:developer_wiki_source_capture/models/source_template.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('image source template matches the wiki contract', () {
+    expect(imageSourceTemplate.name, '🖼️ Bild-Quelle');
+    expect(imageSourceTemplate.titlePrefix, '[Bild-Quelle]: ');
+    expect(
+      imageSourceTemplate.fields.map((field) => field.id),
+      ['content', 'description', 'agent_notes', 'prompt_additions'],
+    );
+    expect(imageSourceTemplate.fields.first.kind, FieldKind.image);
+    expect(imageSourceTemplate.fields.first.required, isTrue);
+    expect(
+      imageSourceTemplate.fields.last.initialValue,
+      agentInstruction,
+    );
+  });
+}

--- a/test/image_validation_service_test.dart
+++ b/test/image_validation_service_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:developer_wiki_source_capture/models/image_source_file.dart';
+import 'package:developer_wiki_source_capture/services/image_validation_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory directory;
+  final service = ImageValidationService();
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('image-validation-');
+  });
+
+  tearDown(() async {
+    await directory.delete(recursive: true);
+  });
+
+  test('accepts matching PNG metadata and signature', () async {
+    final file = File('${directory.path}/source.png');
+    await file.writeAsBytes(
+      const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+    );
+
+    final validated = await service.validate(
+      ImageSourceFile(
+        path: file.path,
+        name: 'source.png',
+        mimeType: 'image/png',
+        sizeBytes: 1,
+      ),
+    );
+
+    expect(validated.sizeBytes, 8);
+    expect(validated.mimeType, 'image/png');
+  });
+
+  test('rejects unsupported MIME type', () async {
+    final file = File('${directory.path}/source.webp');
+    await file.writeAsBytes(const [0x52, 0x49, 0x46, 0x46]);
+
+    await expectLater(
+      service.validate(
+        ImageSourceFile(
+          path: file.path,
+          name: 'source.webp',
+          mimeType: 'image/webp',
+          sizeBytes: 4,
+        ),
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('rejects a signature that does not match the MIME type', () async {
+    final file = File('${directory.path}/source.png');
+    await file.writeAsBytes('GIF89a'.codeUnits);
+
+    await expectLater(
+      service.validate(
+        ImageSourceFile(
+          path: file.path,
+          name: 'source.png',
+          mimeType: 'image/png',
+          sizeBytes: 6,
+        ),
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('rejects images larger than ten MiB', () async {
+    final file = File('${directory.path}/large.jpg');
+    final randomAccess = await file.open(mode: FileMode.write);
+    await randomAccess.truncate(ImageValidationService.maxBytes + 1);
+    await randomAccess.close();
+
+    await expectLater(
+      service.validate(
+        ImageSourceFile(
+          path: file.path,
+          name: 'large.jpg',
+          mimeType: 'image/jpeg',
+          sizeBytes: ImageValidationService.maxBytes + 1,
+        ),
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -1,5 +1,9 @@
+import 'dart:io';
+
+import 'package:developer_wiki_source_capture/models/image_source_file.dart';
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/screens/source_form_screen.dart';
+import 'package:developer_wiki_source_capture/services/image_input_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -87,4 +91,88 @@ void main() {
 
     expect(tester.widget<SizedBox>(clearance).height, 88);
   });
+
+  testWidgets('shows, replaces and removes an image source preview', (
+    tester,
+  ) async {
+    final directory = await Directory.systemTemp.createTemp('image-form-');
+    addTearDown(() => directory.delete(recursive: true));
+    final file = File('${directory.path}/source.png');
+    await file.writeAsBytes(
+      const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+    );
+    final gateway = _FakeImageInputGateway(
+      ImageSourceFile(
+        path: file.path,
+        name: 'source.png',
+        mimeType: 'image/png',
+        sizeBytes: 8,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SourceFormScreen(
+          initialTemplate: imageSourceTemplate,
+          imageInputGateway: gateway,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('image-source-pick-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('image-source-preview')), findsOneWidget);
+    expect(find.textContaining('source.png'), findsOneWidget);
+    expect(find.text('Ersetzen'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('image-source-remove-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('image-source-preview')), findsNothing);
+    expect(gateway.discarded, hasLength(1));
+  });
+
+  testWidgets('does not prepare an image source without an image', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SourceFormScreen(
+          initialTemplate: imageSourceTemplate,
+          imageInputGateway: _FakeImageInputGateway(null),
+        ),
+      ),
+    );
+
+    final saveButton = find.byKey(const Key('source-form-save-button'));
+    await tester.scrollUntilVisible(
+      saveButton,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(saveButton);
+    await tester.pump();
+
+    expect(find.text('Bitte markierte Pflichtfelder prüfen.'), findsOneWidget);
+    expect(
+      find.textContaining('Die Bild-Quelle ist lokal vorbereitet'),
+      findsNothing,
+    );
+  });
+}
+
+class _FakeImageInputGateway implements ImageInputGateway {
+  _FakeImageInputGateway(this.image);
+
+  final ImageSourceFile? image;
+  final discarded = <ImageSourceFile>[];
+
+  @override
+  Future<void> discard(ImageSourceFile image) async {
+    discarded.add(image);
+  }
+
+  @override
+  Future<ImageSourceFile?> pickImage() async => image;
 }


### PR DESCRIPTION
## Zusammenfassung

- führt den Quellentyp **Bild-Quelle** mit dem vereinbarten Feldvertrag ein
- übernimmt PNG-, GIF- und JPEG-Dateien bis 10 MiB unverändert in den privaten App-Cache
- validiert MIME-Typ, Dateigröße und Dateisignatur
- ergänzt Vorschau, Ersetzen, Entfernen und den Metadaten-Hinweis
- kapselt die Plattformauswahl hinter einem testbaren Gateway

## Stack

Erster PR der Kette. Der Android-Share-Einstieg und der GitHub-Attachment-Ablauf folgen in darauf aufbauenden PRs.

## Tests

- Unit-Tests für Bildvalidierung und Template-Vertrag ergänzt
- Widget-Tests für Auswahl, Vorschau, Entfernen und Pflichtfeldprüfung ergänzt
- Flutter/Dart-Tests konnten in der verfügbaren Ausführungsumgebung nicht gestartet werden, da dort weder Flutter noch Dart installiert ist

## Lizenzprüfung

Keine neue Abhängigkeit und kein neues Fremd-Asset. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #94
Part of #90