### PR TITLE
Bilder über Android direkt als Bild-Quelle teilen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 - Grundlage für Bild-Quellen mit eigenem Quellentyp, validierter Bildauswahl,
   Vorschau sowie Entfernen und Ersetzen des unveränderten Originalbilds.
+- Drittes Android-Share-Ziel für PNG-, GIF- und JPEG-Bilder, das geteilte
+  `content://`-Inhalte in denselben privaten Bildquellen-Entwurf übernimmt.
 - Verbindliche Projektdokumentation unter `docs/` mit C4-orientierter Architekturübersicht.
 - Dokumentationsregeln für Changelog, README und technische Dokumentation im Implementierungsworkflow.
 - Direkt in den Einstellungen aufrufbare Hilfe zum Erstellen eines Fine-grained GitHub PAT mit den benötigten Least-Privilege-Berechtigungen.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Der aktuelle Funktionsumfang umfasst unter anderem:
 - Prüfung der Wiki-Verbindung und des PAT,
 - Start und Statusabfrage des konfigurierten GitHub-Actions-Workflows,
 - geschützte lokale Speicherung der Konfiguration,
-- Android-Share als zusätzlicher Einstieg in die Quellenerfassung.
+- Android-Share mit getrennten Zielen für Links, Text und Bilder als
+  zusätzlicher Einstieg in dieselbe Quellenerfassung.
 
 Die Quellenformulare sind derzeit versioniert in `lib/models/source_template.dart` enthalten. Dadurch bleibt die App offline startbar und externe Template-Änderungen beeinflussen UI und Requests nicht ungeprüft. Eine spätere Version kann Templates lesend aus dem Wiki laden und eine geprüfte lokale Fallback-Version behalten.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,19 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity-alias>
+        <activity-alias
+            android:name=".ShareImageActivity"
+            android:targetActivity=".MainActivity"
+            android:exported="true"
+            android:label="Developer Wiki – Bild">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/png" />
+                <data android:mimeType="image/gif" />
+                <data android:mimeType="image/jpeg" />
+            </intent-filter>
+        </activity-alias>
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
@@ -250,7 +250,7 @@ class MainActivity : FlutterActivity() {
                 "text" to "Das geteilte Bild konnte nicht gelesen werden."
             )
             return try {
-                mapOf("kind" to "image") + copyImageToPrivateCache(uri)
+                copyImageToPrivateCache(uri) + ("kind" to "image")
             } catch (error: Exception) {
                 mapOf(
                     "kind" to "image_error",

--- a/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
@@ -3,6 +3,7 @@ package de.huluvu.developer_wiki_source_capture
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.provider.OpenableColumns
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -19,7 +20,7 @@ class MainActivity : FlutterActivity() {
     }
 
     private var shareChannel: MethodChannel? = null
-    private var pendingShare: Map<String, String>? = null
+    private var pendingShare: Map<String, Any>? = null
     private var imagePickerResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -238,8 +239,26 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    private fun sharedContentFrom(sourceIntent: Intent?): Map<String, String>? {
-        if (sourceIntent?.action != Intent.ACTION_SEND || sourceIntent.type != "text/plain") {
+    private fun sharedContentFrom(sourceIntent: Intent?): Map<String, Any>? {
+        if (sourceIntent?.action != Intent.ACTION_SEND) {
+            return null
+        }
+        val mimeType = sourceIntent.type?.lowercase()
+        if (mimeType in SUPPORTED_IMAGE_TYPES) {
+            val uri = sharedImageUri(sourceIntent) ?: return mapOf(
+                "kind" to "image_error",
+                "text" to "Das geteilte Bild konnte nicht gelesen werden."
+            )
+            return try {
+                mapOf("kind" to "image") + copyImageToPrivateCache(uri)
+            } catch (error: Exception) {
+                mapOf(
+                    "kind" to "image_error",
+                    "text" to (error.message ?: "Das Bild konnte nicht übernommen werden.")
+                )
+            }
+        }
+        if (mimeType != "text/plain") {
             return null
         }
         val text = sourceIntent.getStringExtra(Intent.EXTRA_TEXT)?.trim().orEmpty()
@@ -250,5 +269,14 @@ class MainActivity : FlutterActivity() {
         val componentName = sourceIntent.component?.className.orEmpty()
         val kind = if (componentName.endsWith("ShareLinkActivity")) "link" else "text"
         return mapOf("kind" to kind, "text" to text)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun sharedImageUri(sourceIntent: Intent): Uri? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            sourceIntent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            sourceIntent.getParcelableExtra(Intent.EXTRA_STREAM)
+        }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,9 @@ flowchart TB
 - Bilddateien werden über eine gekapselte Plattformabstraktion ausgewählt,
   anhand von Dateityp, Größe und Signatur validiert und nur unverändert im
   privaten temporären App-Speicher gehalten.
+- Das Android-Bild-Share-Ziel kopiert eingehende `content://`-URIs unmittelbar
+  in diesen privaten Speicher. Danach durchlaufen sie dieselbe Validierung und
+  dasselbe Bildquellenformular wie manuell ausgewählte Dateien.
 - Konfigurierbare Werte wie Ziel-Repository und Workflow-Datei werden nicht unnötig im UI-Code fest verdrahtet.
 - Die Architektur bleibt mobile-first, testbar und so einfach wie für den aktuellen Funktionsumfang möglich.
 

--- a/lib/models/shared_content.dart
+++ b/lib/models/shared_content.dart
@@ -1,13 +1,21 @@
-enum SharedContentKind { link, text }
+import 'image_source_file.dart';
+
+enum SharedContentKind { link, text, image, imageError }
 
 class SharedContent {
   const SharedContent({
     required this.kind,
-    required this.text,
+    this.text = '',
+    this.image,
   });
 
   final SharedContentKind kind;
   final String text;
+  final ImageSourceFile? image;
 
-  bool get isEmpty => text.trim().isEmpty;
+  bool get isEmpty => switch (kind) {
+        SharedContentKind.image => image == null,
+        SharedContentKind.imageError => text.trim().isEmpty,
+        SharedContentKind.link || SharedContentKind.text => text.trim().isEmpty,
+      };
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -16,10 +16,12 @@ class HomeScreen extends StatefulWidget {
     super.key,
     this.onImportRequested,
     this.sharedContent,
+    this.sourceFormBuilder,
   });
 
   final VoidCallback? onImportRequested;
   final SharedContent? sharedContent;
+  final Widget Function(SourceTemplate, SharedContent?)? sourceFormBuilder;
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -34,15 +36,48 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _importFailed = false;
   DateTime? _lastDispatchAt;
   WorkflowRun? _workflowRun;
+  String? _openedSharedImagePath;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleSharedImage();
+  }
+
+  @override
+  void didUpdateWidget(covariant HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sharedContent != widget.sharedContent) {
+      _scheduleSharedImage();
+    }
+  }
+
+  void _scheduleSharedImage() {
+    final content = widget.sharedContent;
+    final path = content?.image?.path;
+    if (content?.kind != SharedContentKind.image ||
+        path == null ||
+        path == _openedSharedImagePath) {
+      return;
+    }
+    _openedSharedImagePath = path;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _openSource(imageSourceTemplate);
+      }
+    });
+  }
 
   void _openSource(SourceTemplate template) {
+    final customBuilder = widget.sourceFormBuilder;
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => SourceFormScreen(
-          initialTemplate: template,
-          sharedContent: widget.sharedContent,
-        ),
+        builder: (_) => customBuilder?.call(template, widget.sharedContent) ??
+            SourceFormScreen(
+              initialTemplate: template,
+              sharedContent: widget.sharedContent,
+            ),
       ),
     );
   }
@@ -219,6 +254,19 @@ class _HomeScreenState extends State<HomeScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          if (widget.sharedContent?.kind == SharedContentKind.imageError) ...[
+            Card(
+              color: Theme.of(context).colorScheme.errorContainer,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Geteiltes Bild konnte nicht übernommen werden: '
+                  '${widget.sharedContent!.text}',
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+          ],
           Text(
             isShared ? 'Geteilten Inhalt erfassen' : 'Neue Quelle erfassen',
             style: Theme.of(context).textTheme.titleLarge,

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -56,6 +56,11 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     _imageInputGateway =
         widget.imageInputGateway ?? PlatformImageInputGateway();
     _select(widget.initialTemplate ?? sourceTemplates.first);
+    final sharedImage = widget.sharedContent?.image;
+    if (widget.sharedContent?.kind == SharedContentKind.image &&
+        sharedImage != null) {
+      _image = sharedImage;
+    }
   }
 
   void _select(SourceTemplate next) {

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/services.dart';
 
+import '../models/image_source_file.dart';
 import '../models/shared_content.dart';
+import 'image_validation_service.dart';
 
 class ShareIntentService {
-  static const _channel = MethodChannel('developer_wiki/share');
+  ShareIntentService({
+    MethodChannel? channel,
+    ImageValidationService? validationService,
+  })  : _channel = channel ?? const MethodChannel('developer_wiki/share'),
+        _validationService = validationService ?? ImageValidationService();
+
+  final MethodChannel _channel;
+  final ImageValidationService _validationService;
 
   Future<SharedContent?> initialize(
     void Function(SharedContent content) onShared,
@@ -12,7 +21,7 @@ class ShareIntentService {
       if (call.method != 'shared') {
         return;
       }
-      final content = _fromMap(call.arguments);
+      final content = await _fromMap(call.arguments);
       if (content != null && !content.isEmpty) {
         onShared(content);
       }
@@ -28,12 +37,40 @@ class ShareIntentService {
     }
   }
 
-  SharedContent? _fromMap(Object? value) {
+  Future<SharedContent?> _fromMap(Object? value) async {
     if (value is! Map) {
       return null;
     }
     final kindValue = value['kind']?.toString();
     final text = value['text']?.toString() ?? '';
+    if (kindValue == 'image_error') {
+      return SharedContent(kind: SharedContentKind.imageError, text: text);
+    }
+    if (kindValue == 'image') {
+      final image = ImageSourceFile(
+        path: value['path']?.toString() ?? '',
+        name: value['name']?.toString() ?? '',
+        mimeType: value['mimeType']?.toString() ?? '',
+        sizeBytes: _asInt(value['sizeBytes']),
+      );
+      if (image.path.isEmpty || image.name.isEmpty || image.mimeType.isEmpty) {
+        return const SharedContent(
+          kind: SharedContentKind.imageError,
+          text: 'Das geteilte Bild ist unvollständig.',
+        );
+      }
+      try {
+        return SharedContent(
+          kind: SharedContentKind.image,
+          image: await _validationService.validate(image),
+        );
+      } on FormatException catch (error) {
+        return SharedContent(
+          kind: SharedContentKind.imageError,
+          text: error.message.toString(),
+        );
+      }
+    }
     final kind = switch (kindValue) {
       'link' => SharedContentKind.link,
       'text' => SharedContentKind.text,
@@ -43,5 +80,9 @@ class ShareIntentService {
       return null;
     }
     return SharedContent(kind: kind, text: text);
+  }
+
+  int _asInt(Object? value) {
+    return value is int ? value : int.tryParse(value?.toString() ?? '') ?? 0;
   }
 }

--- a/lib/services/source_prefill_service.dart
+++ b/lib/services/source_prefill_service.dart
@@ -8,6 +8,10 @@ class SourcePrefillService {
     SourceTemplate template,
     SharedContent content,
   ) {
+    if (content.kind == SharedContentKind.image ||
+        content.kind == SharedContentKind.imageError) {
+      return const {};
+    }
     final text = content.text.trim();
     if (text.isEmpty) {
       return const {};

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:developer_wiki_source_capture/models/shared_content.dart';
+import 'package:developer_wiki_source_capture/models/image_source_file.dart';
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/screens/home_screen.dart';
 import 'package:flutter/material.dart';
@@ -72,5 +73,33 @@ void main() {
       find.text('Geteilter Inhalt wurde vorausgefüllt und kann bearbeitet werden.'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('shared image opens the image source form directly', (
+    tester,
+  ) async {
+    const sharedContent = SharedContent(
+      kind: SharedContentKind.image,
+      image: ImageSourceFile(
+        path: '/private/image.png',
+        name: 'image.png',
+        mimeType: 'image/png',
+        sizeBytes: 8,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HomeScreen(
+          sharedContent: sharedContent,
+          sourceFormBuilder: (template, content) => Text(
+            '${template.name}:${content?.image?.name}',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('🖼️ Bild-Quelle:image.png'), findsOneWidget);
   });
 }

--- a/test/share_intent_service_test.dart
+++ b/test/share_intent_service_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:developer_wiki_source_capture/models/shared_content.dart';
+import 'package:developer_wiki_source_capture/services/share_intent_service.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('developer_wiki/share-test');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('validates an initially shared image through the common path', () async {
+    final directory = await Directory.systemTemp.createTemp('shared-image-');
+    addTearDown(() => directory.delete(recursive: true));
+    final file = File('${directory.path}/shared.png');
+    await file.writeAsBytes(
+      const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'getInitialShare');
+      return {
+        'kind': 'image',
+        'path': file.path,
+        'name': 'shared.png',
+        'mimeType': 'image/png',
+        'sizeBytes': 8,
+      };
+    });
+
+    final content = await ShareIntentService(
+      channel: channel,
+    ).initialize((_) {});
+
+    expect(content?.kind, SharedContentKind.image);
+    expect(content?.image?.name, 'shared.png');
+  });
+
+  test('turns native image errors into user-visible shared content', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async => {
+              'kind': 'image_error',
+              'text': 'Datei zu groß',
+            });
+
+    final content = await ShareIntentService(
+      channel: channel,
+    ).initialize((_) {});
+
+    expect(content?.kind, SharedContentKind.imageError);
+    expect(content?.text, 'Datei zu groß');
+  });
+}


### PR DESCRIPTION
## Zusammenfassung

- ergänzt **Developer Wiki – Bild** als drittes Android-Share-Ziel für PNG, GIF und JPEG
- liest ausschließlich den vom Share-Intent gelieferten `content://`-Stream und kopiert ihn sofort in den privaten App-Cache
- führt geteilte Bilder durch dieselbe Größen-, MIME- und Signaturvalidierung wie manuell ausgewählte Bilder
- öffnet nach erfolgreicher Übernahme direkt denselben Bildquellen-Entwurf
- zeigt verständliche Fehler für ungültige oder nicht lesbare Share-Inhalte

## Stack

- baut auf #96 / `story/94-image-source-foundation` auf
- Basis dieses PRs ist deshalb bewusst der vorherige Story-Branch
- der GitHub-Attachment-Ablauf folgt im nächsten PR

## Tests

- Service-Test für valide und fehlerhafte Android-Bild-Share-Daten
- Widget-Test für die direkte Navigation in den Bildquellen-Entwurf
- Flutter/Dart-Tests konnten in der verfügbaren Ausführungsumgebung nicht gestartet werden, da dort weder Flutter noch Dart installiert ist

## Lizenzprüfung

Keine neue Abhängigkeit und kein neues Fremd-Asset. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #95
Part of #90