### PR TITLE
Vollständigen Bildquellen-Workflow auf master konsolidieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
   Vorschau sowie Entfernen und Ersetzen des unveränderten Originalbilds.
 - Drittes Android-Share-Ziel für PNG-, GIF- und JPEG-Bilder, das geteilte
   `content://`-Inhalte in denselben privaten Bildquellen-Entwurf übernimmt.
+- Unterbrechbarer GitHub-Attachment-Ablauf für Bild-Quellen: unlabeled
+  Pending-Issue, Upload im GitHub-Markdown-Editor, Prüfung einer stabilen
+  `user-attachments`-URL und erst danach Veröffentlichung mit `quelle`.
 - Verbindliche Projektdokumentation unter `docs/` mit C4-orientierter Architekturübersicht.
 - Dokumentationsregeln für Changelog, README und technische Dokumentation im Implementierungsworkflow.
 - Direkt in den Einstellungen aufrufbare Hilfe zum Erstellen eines Fine-grained GitHub PAT mit den benötigten Least-Privilege-Berechtigungen.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ flutter run
 
 Beim ersten Start das Ziel-Wiki, das Fine-grained PAT und den per `workflow_dispatch` startbaren Import-Workflow konfigurieren. Anschließend können Quellen erfasst und als Issues im Wiki gespeichert werden.
 
+Für Bild-Quellen erstellt die App zunächst ein noch nicht importierbares
+Pending-Issue und öffnet dessen GitHub-Kommentarbereich. Dort das Bild auswählen,
+den Kommentar absenden und anschließend in der App den Upload prüfen. Der genaue
+Ablauf und die technische Begründung stehen in der
+[Bildquellen-Dokumentation](docs/image-sources.md).
+
 ## Dokumentation
 
 Die weiterführende Projektdokumentation liegt unter [`docs/`](docs/README.md):
@@ -84,6 +90,7 @@ Die weiterführende Projektdokumentation liegt unter [`docs/`](docs/README.md):
 - [Architektur nach dem C4-Modell](docs/architecture.md)
 - [App-Logo und Launcher-Icons](docs/app-icon.md)
 - [Signierter Android-Release über GitHub Actions](docs/android-release.md)
+- [Bild-Quellen und GitHub-Attachments](docs/image-sources.md)
 
 Änderungen an Features, Bugfixes oder technischer Infrastruktur aktualisieren die betroffenen Dokumentationsartefakte im selben Pull Request. Das [CHANGELOG](CHANGELOG.md) wird nach Keep a Changelog gepflegt.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Diese Dokumentation ergänzt die kompakte Projektübersicht in der Root-`README.
 - [Architektur](architecture.md) – Systemkontext und Container-Sicht nach dem C4-Modell.
 - [App-Logo und Launcher-Icons](app-icon.md) – Masterdatei, Android-Ressourcen und reproduzierbare Ableitung.
 - [Android-Release](android-release.md) – reproduzierbarer, signierter APK-Release über GitHub Actions.
+- [Bild-Quellen und GitHub-Attachments](image-sources.md) – Eingänge,
+  zweistufiger Upload, Wiederaufnahme und Datenschutz.
 - [Menschliche PR-Abnahme](human-review.md) – lokale Prüfung, Rebase-Merge und Vorgehen bei gestapelten Branches.
 
 ## Dokumentationsregeln

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,12 @@ flowchart TB
 - Das Android-Bild-Share-Ziel kopiert eingehende `content://`-URIs unmittelbar
   in diesen privaten Speicher. Danach durchlaufen sie dieselbe Validierung und
   dasselbe Bildquellenformular wie manuell ausgewählte Dateien.
+- Bild-Attachments werden über ein unlabeled Pending-Issue und den offiziellen
+  GitHub-Markdown-Editor hochgeladen. Die App übernimmt aus einem Kommentar des
+  authentifizierten Kontos genau eine stabile `user-attachments`-Referenz und
+  setzt `quelle` erst nach erfolgreicher Finalisierung.
+- Der Pending-Zustand wird verschlüsselt lokal gespeichert, damit der externe
+  Browserwechsel und ein App-Neustart den Ablauf nicht verlieren.
 - Konfigurierbare Werte wie Ziel-Repository und Workflow-Datei werden nicht unnötig im UI-Code fest verdrahtet.
 - Die Architektur bleibt mobile-first, testbar und so einfach wie für den aktuellen Funktionsumfang möglich.
 

--- a/docs/image-sources.md
+++ b/docs/image-sources.md
@@ -1,0 +1,57 @@
+# Bild-Quellen und GitHub-Attachments
+
+## Unterstützte Eingänge
+
+Die App verarbeitet PNG-, GIF- und JPEG-Bilder bis 10 MiB. Ein Bild kann im
+Bildquellenformular ausgewählt oder über das Android-Share-Ziel
+**Developer Wiki – Bild** übergeben werden. Android liefert dabei regelmäßig
+nur einen `content://`-URI. Die App liest dessen Stream einmalig, kopiert die
+Bytes unverändert in ihren privaten Cache und prüft MIME-Typ, Größe und
+Dateisignatur. Beide Eingänge laufen danach durch dasselbe Formular.
+
+## Warum der Upload zweistufig ist
+
+GitHub stellt für allgemeine Issue-Attachments keine dokumentierte REST- oder
+GraphQL-Upload-API bereit. Deshalb lädt die App die Datei nicht über einen
+nachgebauten internen Endpunkt hoch. Stattdessen wird der von GitHub
+unterstützte Markdown-Editor im Browser verwendet:
+
+1. Die App erstellt ein Pending-Issue ohne Label `quelle`. Sein Inhalt weist
+   ausdrücklich darauf hin, dass es noch nicht importiert werden darf.
+2. Die App öffnet den Kommentarbereich dieses Issues auf GitHub.
+3. Der Mensch wählt dort das Bild aus und sendet den Kommentar ab. Das Bild
+   muss im Browser erneut gewählt werden, weil eine andere App oder ein
+   Browser nicht automatisch auf den privaten Cache der App zugreifen darf.
+4. Nach **Upload prüfen und Quelle veröffentlichen** liest die App die
+   Issue-Kommentare über die GitHub Issues API. Berücksichtigt werden nur
+   Kommentare des aktuell authentifizierten GitHub-Kontos.
+5. Genau eine stabile URL der Form
+   `https://github.com/user-attachments/assets/<uuid>` muss vorhanden sein.
+   Temporäre signierte Download-URLs und fremde Links werden nicht übernommen.
+6. Die App ersetzt den Pending-Inhalt durch das finale Bild-Markdown und setzt
+   erst als letzten Schritt das Label `quelle`. Erst jetzt kann der Wiki-Import
+   das Issue verarbeiten.
+
+Bei der Verarbeitung löst das Developer-Wiki die stabile Attachment-Referenz
+über die GitHub-Markdown-Verarbeitung in eine kurzlebige signierte Download-URL
+auf. Ein direkter Download der stabilen Referenz ist nicht Teil des App-Ablaufs.
+
+## Unterbrechung und Aufräumen
+
+Der Pending-Zustand einschließlich Issue-Nummer, Formulardaten und privatem
+Cache-Pfad wird im geschützten lokalen Speicher abgelegt. Nach einem App-Neustart
+erscheint er auf der Startseite und kann fortgesetzt werden. Beim erfolgreichen
+Abschluss wird die temporäre Datei entfernt. **Upload verwerfen** schließt das
+Pending-Issue als nicht geplant, löscht den lokalen Zustand und entfernt die
+temporäre Datei.
+
+Der private Android-Cache kann vom Betriebssystem bereinigt werden. Wurde der
+Kommentar bereits hochgeladen, bleibt die Abschlussprüfung trotzdem möglich,
+weil sie ausschließlich die stabile GitHub-Referenz benötigt.
+
+## Datenschutz
+
+Die App verändert oder bereinigt das Originalbild nicht. Insbesondere können
+Fotos EXIF-Daten wie Aufnahmeort, Zeitpunkt oder Geräteinformationen enthalten.
+Vor dem Upload muss deshalb geprüft werden, ob das unveränderte Bild geteilt
+werden darf.

--- a/lib/models/github_issue_comment.dart
+++ b/lib/models/github_issue_comment.dart
@@ -1,0 +1,11 @@
+class GitHubIssueComment {
+  const GitHubIssueComment({
+    required this.body,
+    required this.createdAt,
+    required this.authorLogin,
+  });
+
+  final String body;
+  final DateTime createdAt;
+  final String authorLogin;
+}

--- a/lib/models/pending_image_upload.dart
+++ b/lib/models/pending_image_upload.dart
@@ -1,0 +1,53 @@
+import 'image_source_file.dart';
+
+class PendingImageUpload {
+  const PendingImageUpload({
+    required this.issueNumber,
+    required this.issueUrl,
+    required this.createdAt,
+    required this.title,
+    required this.values,
+    required this.image,
+  });
+
+  final int issueNumber;
+  final String issueUrl;
+  final DateTime createdAt;
+  final String title;
+  final Map<String, String> values;
+  final ImageSourceFile image;
+
+  Map<String, Object> toJson() => {
+        'issueNumber': issueNumber,
+        'issueUrl': issueUrl,
+        'createdAt': createdAt.toUtc().toIso8601String(),
+        'title': title,
+        'values': values,
+        'image': {
+          'path': image.path,
+          'name': image.name,
+          'mimeType': image.mimeType,
+          'sizeBytes': image.sizeBytes,
+        },
+      };
+
+  factory PendingImageUpload.fromJson(Map<String, dynamic> json) {
+    final rawValues = json['values'] as Map<String, dynamic>? ?? const {};
+    final rawImage = json['image'] as Map<String, dynamic>? ?? const {};
+    return PendingImageUpload(
+      issueNumber: json['issueNumber'] as int,
+      issueUrl: json['issueUrl'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String).toUtc(),
+      title: json['title'] as String,
+      values: rawValues.map(
+        (key, value) => MapEntry(key, value.toString()),
+      ),
+      image: ImageSourceFile(
+        path: rawImage['path'] as String,
+        name: rawImage['name'] as String,
+        mimeType: rawImage['mimeType'] as String,
+        sizeBytes: rawImage['sizeBytes'] as int,
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../models/pending_image_upload.dart';
 import '../models/shared_content.dart';
 import '../models/source_template.dart';
 import '../models/wiki_configuration.dart';
@@ -7,6 +8,7 @@ import '../models/workflow_run.dart';
 import '../services/configuration_service.dart';
 import '../services/external_url_service.dart';
 import '../services/github_service.dart';
+import '../services/image_upload_service.dart';
 import 'recent_sources_screen.dart';
 import 'settings_screen.dart';
 import 'source_form_screen.dart';
@@ -17,11 +19,13 @@ class HomeScreen extends StatefulWidget {
     this.onImportRequested,
     this.sharedContent,
     this.sourceFormBuilder,
+    this.imageUploadGateway,
   });
 
   final VoidCallback? onImportRequested;
   final SharedContent? sharedContent;
   final Widget Function(SourceTemplate, SharedContent?)? sourceFormBuilder;
+  final ImageUploadGateway? imageUploadGateway;
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -37,11 +41,45 @@ class _HomeScreenState extends State<HomeScreen> {
   DateTime? _lastDispatchAt;
   WorkflowRun? _workflowRun;
   String? _openedSharedImagePath;
+  late final ImageUploadGateway _imageUploadGateway;
+  PendingImageUpload? _pendingImageUpload;
 
   @override
   void initState() {
     super.initState();
+    _imageUploadGateway =
+        widget.imageUploadGateway ?? GitHubImageUploadService();
+    _loadPendingImageUpload();
     _scheduleSharedImage();
+  }
+
+  Future<void> _loadPendingImageUpload() async {
+    try {
+      final pending = await _imageUploadGateway.loadPending();
+      if (mounted) {
+        setState(() => _pendingImageUpload = pending);
+      }
+    } catch (_) {
+      // Die normale Quellenerfassung bleibt bei defektem Altzustand nutzbar.
+    }
+  }
+
+  Future<void> _openPendingImageUpload() async {
+    final pending = _pendingImageUpload;
+    if (pending == null) {
+      return;
+    }
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SourceFormScreen(
+          initialTemplate: imageSourceTemplate,
+          pendingUpload: pending,
+          imageUploadGateway: _imageUploadGateway,
+        ),
+      ),
+    );
+    await _loadPendingImageUpload();
   }
 
   @override
@@ -254,6 +292,21 @@ class _HomeScreenState extends State<HomeScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          if (_pendingImageUpload != null) ...[
+            Card(
+              child: ListTile(
+                key: const Key('pending-image-upload'),
+                leading: const Icon(Icons.cloud_upload_outlined),
+                title: Text(
+                  'Bild-Upload #${_pendingImageUpload!.issueNumber} fortsetzen',
+                ),
+                subtitle: Text(_pendingImageUpload!.image.name),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: _openPendingImageUpload,
+              ),
+            ),
+            const SizedBox(height: 16),
+          ],
           if (widget.sharedContent?.kind == SharedContentKind.imageError) ...[
             Card(
               color: Theme.of(context).colorScheme.errorContainer,

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../models/created_issue.dart';
 import '../models/image_source_file.dart';
+import '../models/pending_image_upload.dart';
 import '../models/shared_content.dart';
 import '../models/source_template.dart';
 import '../models/wiki_configuration.dart';
@@ -12,6 +13,7 @@ import '../services/configuration_service.dart';
 import '../services/external_url_service.dart';
 import '../services/github_service.dart';
 import '../services/image_input_service.dart';
+import '../services/image_upload_service.dart';
 import '../services/source_prefill_service.dart';
 import 'settings_screen.dart';
 
@@ -21,11 +23,15 @@ class SourceFormScreen extends StatefulWidget {
     this.initialTemplate,
     this.sharedContent,
     this.imageInputGateway,
+    this.imageUploadGateway,
+    this.pendingUpload,
   });
 
   final SourceTemplate? initialTemplate;
   final SharedContent? sharedContent;
   final ImageInputGateway? imageInputGateway;
+  final ImageUploadGateway? imageUploadGateway;
+  final PendingImageUpload? pendingUpload;
 
   @override
   State<SourceFormScreen> createState() => _SourceFormScreenState();
@@ -40,6 +46,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   final _externalUrlService = ExternalUrlService();
   final _prefillService = SourcePrefillService();
   late final ImageInputGateway _imageInputGateway;
+  late final ImageUploadGateway _imageUploadGateway;
   late SourceTemplate template;
   final values = <String, TextEditingController>{};
   bool busy = false;
@@ -47,7 +54,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   bool _useSharedContent = true;
   CreatedIssue? _createdIssue;
   ImageSourceFile? _image;
-  bool _imagePrepared = false;
+  PendingImageUpload? _pendingUpload;
   String? _errorMessage;
 
   @override
@@ -55,9 +62,19 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     super.initState();
     _imageInputGateway =
         widget.imageInputGateway ?? PlatformImageInputGateway();
+    _imageUploadGateway =
+        widget.imageUploadGateway ?? GitHubImageUploadService();
     _select(widget.initialTemplate ?? sourceTemplates.first);
+    final pendingUpload = widget.pendingUpload;
     final sharedImage = widget.sharedContent?.image;
-    if (widget.sharedContent?.kind == SharedContentKind.image &&
+    if (pendingUpload != null) {
+      _pendingUpload = pendingUpload;
+      _image = pendingUpload.image;
+      title.text = pendingUpload.title;
+      for (final entry in pendingUpload.values.entries) {
+        values[entry.key]?.text = entry.value;
+      }
+    } else if (widget.sharedContent?.kind == SharedContentKind.image &&
         sharedImage != null) {
       _image = sharedImage;
     }
@@ -87,7 +104,6 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       }
     }
     _createdIssue = null;
-    _imagePrepared = false;
     _errorMessage = null;
   }
 
@@ -102,27 +118,24 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       busy = true;
       _errorMessage = null;
     });
-    if (template == imageSourceTemplate) {
-      setState(() {
-        busy = false;
-        _imagePrepared = true;
-      });
-      return;
-    }
     try {
-      final configuration = await _configurationService.load();
-      final repository = _repositoryFrom(configuration);
-      final map = values.map((key, value) => MapEntry(key, value.text));
-      final issue = await GitHubService(
-        configuration.token,
-        owner: repository.owner,
-        repo: repository.name,
-      ).createIssue(
-        title: '${template.titlePrefix}${title.text.trim()}',
-        body: GitHubService.issueBody(template, map),
-      );
-      if (mounted) {
-        setState(() => _createdIssue = issue);
+      if (template == imageSourceTemplate) {
+        await _submitImageSource();
+      } else {
+        final configuration = await _configurationService.load();
+        final repository = _repositoryFrom(configuration);
+        final map = values.map((key, value) => MapEntry(key, value.text));
+        final issue = await GitHubService(
+          configuration.token,
+          owner: repository.owner,
+          repo: repository.name,
+        ).createIssue(
+          title: '${template.titlePrefix}${title.text.trim()}',
+          body: GitHubService.issueBody(template, map),
+        );
+        if (mounted) {
+          setState(() => _createdIssue = issue);
+        }
       }
     } catch (error) {
       if (mounted) {
@@ -134,6 +147,36 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       if (mounted) {
         setState(() => busy = false);
       }
+    }
+  }
+
+  Future<void> _submitImageSource() async {
+    final pending = _pendingUpload;
+    if (pending == null) {
+      final image = _image!;
+      final map = values.map((key, value) => MapEntry(key, value.text));
+      final started = await _imageUploadGateway.start(
+        title: title.text,
+        values: map,
+        image: image,
+      );
+      if (mounted) {
+        setState(() => _pendingUpload = started);
+      }
+      return;
+    }
+
+    final issue = await _imageUploadGateway.verify(pending);
+    final image = _image;
+    if (image != null) {
+      unawaited(_imageInputGateway.discard(image));
+    }
+    if (mounted) {
+      setState(() {
+        _pendingUpload = null;
+        _image = null;
+        _createdIssue = issue;
+      });
     }
   }
 
@@ -154,7 +197,6 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     setState(() {
       _imageBusy = true;
       _errorMessage = null;
-      _imagePrepared = false;
     });
     try {
       final selected = await _imageInputGateway.pickImage();
@@ -187,7 +229,6 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     }
     setState(() {
       _image = null;
-      _imagePrepared = false;
     });
     try {
       await _imageInputGateway.discard(image);
@@ -238,6 +279,55 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     }
   }
 
+  Future<void> _openPendingUpload() async {
+    final pending = _pendingUpload;
+    if (pending == null) {
+      return;
+    }
+    try {
+      await _imageUploadGateway.open(pending);
+    } catch (error) {
+      if (mounted) {
+        setState(
+          () => _errorMessage =
+              'Pending-Issue konnte nicht geöffnet werden: $error',
+        );
+      }
+    }
+  }
+
+  Future<void> _discardPendingUpload() async {
+    final pending = _pendingUpload;
+    if (pending == null) {
+      return;
+    }
+    setState(() {
+      busy = true;
+      _errorMessage = null;
+    });
+    try {
+      await _imageUploadGateway.discard(pending);
+      await _imageInputGateway.discard(pending.image);
+      if (mounted) {
+        setState(() {
+          _pendingUpload = null;
+          _image = null;
+        });
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(
+          () => _errorMessage =
+              'Upload konnte nicht verworfen werden: $error',
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => busy = false);
+      }
+    }
+  }
+
   void _startNewSource() {
     _useSharedContent = false;
     title.clear();
@@ -253,7 +343,6 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     }
     setState(() {
       _createdIssue = null;
-      _imagePrepared = false;
       _errorMessage = null;
     });
   }
@@ -261,7 +350,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   @override
   void dispose() {
     final image = _image;
-    if (image != null) {
+    if (image != null && _pendingUpload == null) {
       unawaited(_imageInputGateway.discard(image));
     }
     title.dispose();
@@ -315,7 +404,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                     ),
                   )
                   .toList(),
-              onChanged: busy
+              onChanged: busy || _pendingUpload != null
                   ? null
                   : (selected) {
                       if (selected != null) {
@@ -328,13 +417,13 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               child: Text(template.description),
             ),
             if (_createdIssue != null) _successCard(_createdIssue!),
-            if (_imagePrepared) _preparedImageCard(),
+            if (_pendingUpload != null) _pendingImageCard(_pendingUpload!),
             if (_errorMessage != null) _errorCard(_errorMessage!),
             ValueListenableBuilder<TextEditingValue>(
               valueListenable: title,
               builder: (context, value, _) => TextFormField(
                 controller: title,
-                enabled: !busy,
+                enabled: !busy && _pendingUpload == null,
                 decoration: InputDecoration(
                   labelText: 'Issue-Titel',
                   prefixText: template.titlePrefix,
@@ -355,7 +444,9 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                 busy
                     ? 'Wird erstellt …'
                     : template == imageSourceTemplate
-                        ? 'Bildquelle vorbereiten'
+                        ? _pendingUpload == null
+                            ? 'Upload auf GitHub starten'
+                            : 'Upload prüfen und Quelle veröffentlichen'
                         : 'Quelle speichern',
               ),
             ),
@@ -378,7 +469,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     }
     return IconButton(
       tooltip: 'Feld leeren',
-      onPressed: busy ? null : controller.clear,
+      onPressed: busy || _pendingUpload != null ? null : controller.clear,
       icon: const Icon(Icons.clear),
     );
   }
@@ -463,7 +554,9 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                   ),
                 )
                 .toList(),
-            onChanged: busy ? null : (selected) => controller.text = selected ?? '',
+            onChanged: busy || _pendingUpload != null
+                ? null
+                : (selected) => controller.text = selected ?? '',
             validator: (selected) =>
                 field.required && selected == null ? 'Pflichtfeld' : null,
           ),
@@ -476,7 +569,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
         valueListenable: controller,
         builder: (context, value, _) => TextFormField(
           controller: controller,
-          enabled: !busy,
+          enabled: !busy && _pendingUpload == null,
           minLines: field.kind == FieldKind.textarea ? 3 : 1,
           maxLines: field.kind == FieldKind.textarea ? 8 : 1,
           decoration: InputDecoration(
@@ -519,7 +612,9 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             if (image == null)
               OutlinedButton.icon(
                 key: const Key('image-source-pick-button'),
-                onPressed: _imageBusy || busy ? null : _pickImage,
+                onPressed: _imageBusy || busy || _pendingUpload != null
+                    ? null
+                    : _pickImage,
                 icon: const Icon(Icons.image_outlined),
                 label: Text(
                   _imageBusy ? 'Bild wird übernommen …' : 'Bild auswählen',
@@ -553,13 +648,17 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                 runSpacing: 8,
                 children: [
                   OutlinedButton.icon(
-                    onPressed: _imageBusy || busy ? null : _pickImage,
+                    onPressed: _imageBusy || busy || _pendingUpload != null
+                        ? null
+                        : _pickImage,
                     icon: const Icon(Icons.swap_horiz),
                     label: const Text('Ersetzen'),
                   ),
                   OutlinedButton.icon(
                     key: const Key('image-source-remove-button'),
-                    onPressed: _imageBusy || busy ? null : _removeImage,
+                    onPressed: _imageBusy || busy || _pendingUpload != null
+                        ? null
+                        : _removeImage,
                     icon: const Icon(Icons.delete_outline),
                     label: const Text('Entfernen'),
                   ),
@@ -592,14 +691,42 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     );
   }
 
-  Widget _preparedImageCard() {
-    return const Card(
-      margin: EdgeInsets.only(bottom: 16),
+  Widget _pendingImageCard(PendingImageUpload upload) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
       child: Padding(
-        padding: EdgeInsets.all(16),
-        child: Text(
-          'Die Bild-Quelle ist lokal vorbereitet. Der GitHub-Attachment-Upload '
-          'wird im abschließenden Teil des gestapelten Ablaufs ergänzt.',
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Bild-Upload für Issue #${upload.issueNumber} ausstehend',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Das Bild im geöffneten GitHub-Issue als Kommentar anhängen und '
+              'den Kommentar absenden. Danach hier den Upload prüfen. Erst bei '
+              'Erfolg wird das Label „quelle“ gesetzt.',
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: busy ? null : _openPendingUpload,
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('GitHub öffnen'),
+                ),
+                TextButton.icon(
+                  onPressed: busy ? null : _discardPendingUpload,
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Upload verwerfen'),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/services/github_attachment_parser.dart
+++ b/lib/services/github_attachment_parser.dart
@@ -1,0 +1,17 @@
+class GitHubAttachmentParser {
+  static final _stableAttachment = RegExp(
+    r'https://github\.com/user-attachments/assets/'
+    r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+    r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+  );
+
+  List<String> stableUrls(Iterable<String> markdownBodies) {
+    final urls = <String>{};
+    for (final body in markdownBodies) {
+      urls.addAll(
+        _stableAttachment.allMatches(body).map((match) => match.group(0)!),
+      );
+    }
+    return urls.toList(growable: false);
+  }
+}

--- a/lib/services/github_service.dart
+++ b/lib/services/github_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/created_issue.dart';
+import '../models/github_issue_comment.dart';
 import '../models/source_issue_summary.dart';
 import '../models/source_template.dart';
 import '../models/workflow_run.dart';
@@ -29,6 +30,7 @@ class GitHubService {
   Future<CreatedIssue> createIssue({
     required String title,
     required String body,
+    List<String> labels = const ['quelle'],
   }) async {
     final response = await _client.post(
       Uri.parse('https://api.github.com/repos/$owner/$repo/issues'),
@@ -36,7 +38,7 @@ class GitHubService {
       body: jsonEncode({
         'title': title,
         'body': body,
-        'labels': ['quelle'],
+        'labels': labels,
       }),
     );
     if (response.statusCode != 201) {
@@ -47,6 +49,74 @@ class GitHubService {
       number: data['number'] as int,
       url: data['html_url'] as String,
     );
+  }
+
+  Future<List<GitHubIssueComment>> listIssueComments(int issueNumber) async {
+    final response = await _client.get(
+      Uri.parse(
+        'https://api.github.com/repos/$owner/$repo/issues/'
+        '$issueNumber/comments',
+      ),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
+    final data = jsonDecode(response.body) as List<dynamic>;
+    return data
+        .cast<Map<String, dynamic>>()
+        .map(
+          (comment) => GitHubIssueComment(
+            body: comment['body']?.toString() ?? '',
+            createdAt: DateTime.parse(comment['created_at'] as String).toUtc(),
+            authorLogin:
+                (comment['user'] as Map<String, dynamic>?)?['login']
+                        ?.toString() ??
+                    '',
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  Future<void> updateIssueBody(int issueNumber, String body) async {
+    await _patchIssue(issueNumber, {'body': body});
+  }
+
+  Future<void> addIssueLabel(int issueNumber, String label) async {
+    final response = await _client.post(
+      Uri.parse(
+        'https://api.github.com/repos/$owner/$repo/issues/'
+        '$issueNumber/labels',
+      ),
+      headers: {..._headers, 'Content-Type': 'application/json'},
+      body: jsonEncode({'labels': [label]}),
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
+  }
+
+  Future<void> closeIssue(int issueNumber) async {
+    await _patchIssue(
+      issueNumber,
+      {'state': 'closed', 'state_reason': 'not_planned'},
+    );
+  }
+
+  Future<void> _patchIssue(
+    int issueNumber,
+    Map<String, Object> payload,
+  ) async {
+    final response = await _client.patch(
+      Uri.parse(
+        'https://api.github.com/repos/$owner/$repo/issues/$issueNumber',
+      ),
+      headers: {..._headers, 'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_message(response));
+    }
   }
 
   Future<List<SourceIssueSummary>> listRecentSourceIssues({

--- a/lib/services/image_upload_service.dart
+++ b/lib/services/image_upload_service.dart
@@ -1,0 +1,155 @@
+import '../models/created_issue.dart';
+import '../models/image_source_file.dart';
+import '../models/pending_image_upload.dart';
+import '../models/source_template.dart';
+import '../models/wiki_configuration.dart';
+import 'configuration_service.dart';
+import 'external_url_service.dart';
+import 'github_attachment_parser.dart';
+import 'github_service.dart';
+import 'pending_image_upload_store.dart';
+
+abstract interface class ImageUploadGateway {
+  Future<PendingImageUpload?> loadPending();
+
+  Future<PendingImageUpload> start({
+    required String title,
+    required Map<String, String> values,
+    required ImageSourceFile image,
+  });
+
+  Future<CreatedIssue> verify(PendingImageUpload upload);
+
+  Future<void> discard(PendingImageUpload upload);
+
+  Future<void> open(PendingImageUpload upload);
+}
+
+class GitHubImageUploadService implements ImageUploadGateway {
+  GitHubImageUploadService({
+    ConfigurationService? configurationService,
+    ExternalUrlService? externalUrlService,
+    PendingImageUploadStore? store,
+    GitHubAttachmentParser? parser,
+  })  : _configurationService =
+            configurationService ?? ConfigurationService(),
+        _externalUrlService = externalUrlService ?? ExternalUrlService(),
+        _store = store ?? PendingImageUploadStore(),
+        _parser = parser ?? GitHubAttachmentParser();
+
+  static const pendingContent =
+      'Bild-Upload ausstehend. Bitte dieses Issue nicht importieren.';
+
+  final ConfigurationService _configurationService;
+  final ExternalUrlService _externalUrlService;
+  final PendingImageUploadStore _store;
+  final GitHubAttachmentParser _parser;
+
+  @override
+  Future<PendingImageUpload?> loadPending() => _store.load();
+
+  @override
+  Future<PendingImageUpload> start({
+    required String title,
+    required Map<String, String> values,
+    required ImageSourceFile image,
+  }) async {
+    final configuration = await _configurationService.load();
+    final service = _githubService(configuration);
+    final startedAt = DateTime.now().toUtc();
+    final pendingValues = {...values, 'content': pendingContent};
+    final issue = await service.createIssue(
+      title: '${imageSourceTemplate.titlePrefix}${title.trim()}',
+      body: GitHubService.issueBody(imageSourceTemplate, pendingValues),
+      labels: const [],
+    );
+    final upload = PendingImageUpload(
+      issueNumber: issue.number,
+      issueUrl: issue.url,
+      createdAt: startedAt,
+      title: title.trim(),
+      values: Map.unmodifiable(values),
+      image: image,
+    );
+    try {
+      await _store.save(upload);
+    } catch (_) {
+      await service.closeIssue(issue.number);
+      rethrow;
+    }
+    try {
+      await open(upload);
+    } catch (_) {
+      // Der persistierte Ablauf kann über „GitHub öffnen“ fortgesetzt werden.
+    }
+    return upload;
+  }
+
+  @override
+  Future<CreatedIssue> verify(PendingImageUpload upload) async {
+    final configuration = await _configurationService.load();
+    final service = _githubService(configuration);
+    final login = await service.login();
+    final comments = await service.listIssueComments(upload.issueNumber);
+    final attachmentUrls = _parser.stableUrls(
+      comments
+          .where((comment) => comment.authorLogin == login)
+          .map((comment) => comment.body),
+    );
+    if (attachmentUrls.isEmpty) {
+      throw const FormatException(
+        'Noch kein GitHub-Attachment gefunden. Das Bild als Kommentar '
+        'hochladen, den Kommentar absenden und erneut prüfen.',
+      );
+    }
+    if (attachmentUrls.length > 1) {
+      throw const FormatException(
+        'Mehrere Attachments gefunden. Bitte nur ein Bild im Pending-Issue '
+        'belassen und erneut prüfen.',
+      );
+    }
+
+    final values = {
+      ...upload.values,
+      'content': _imageMarkdown(upload.image.name, attachmentUrls.single),
+    };
+    await service.updateIssueBody(
+      upload.issueNumber,
+      GitHubService.issueBody(imageSourceTemplate, values),
+    );
+    await service.addIssueLabel(upload.issueNumber, 'quelle');
+    await _store.clear();
+    return CreatedIssue(number: upload.issueNumber, url: upload.issueUrl);
+  }
+
+  @override
+  Future<void> discard(PendingImageUpload upload) async {
+    final configuration = await _configurationService.load();
+    await _githubService(configuration).closeIssue(upload.issueNumber);
+    await _store.clear();
+  }
+
+  @override
+  Future<void> open(PendingImageUpload upload) {
+    return _externalUrlService.open('${upload.issueUrl}#new_comment_field');
+  }
+
+  GitHubService _githubService(WikiConfiguration configuration) {
+    if (!configuration.isComplete) {
+      throw const FormatException(
+        'Wiki-Konfiguration ist unvollständig. Einstellungen prüfen.',
+      );
+    }
+    final repository = GitHubRepository.parse(configuration.repositoryUrl);
+    return GitHubService(
+      configuration.token,
+      owner: repository.owner,
+      repo: repository.name,
+    );
+  }
+
+  String _imageMarkdown(String name, String url) {
+    final safeName = name.replaceAll(RegExp(r'[\[\]\r\n]'), '_');
+    return '![$safeName]($url)';
+  }
+}

--- a/lib/services/pending_image_upload_store.dart
+++ b/lib/services/pending_image_upload_store.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/pending_image_upload.dart';
+
+class PendingImageUploadStore {
+  PendingImageUploadStore({FlutterSecureStorage? storage})
+      : _storage = storage ??
+            const FlutterSecureStorage(
+              aOptions: AndroidOptions(encryptedSharedPreferences: true),
+            );
+
+  static const _key = 'pending_image_upload';
+  final FlutterSecureStorage _storage;
+
+  Future<PendingImageUpload?> load() async {
+    final value = await _storage.read(key: _key);
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    return PendingImageUpload.fromJson(
+      jsonDecode(value) as Map<String, dynamic>,
+    );
+  }
+
+  Future<void> save(PendingImageUpload upload) {
+    return _storage.write(key: _key, value: jsonEncode(upload.toJson()));
+  }
+
+  Future<void> clear() => _storage.delete(key: _key);
+}

--- a/test/github_attachment_parser_test.dart
+++ b/test/github_attachment_parser_test.dart
@@ -1,0 +1,26 @@
+import 'package:developer_wiki_source_capture/services/github_attachment_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final parser = GitHubAttachmentParser();
+
+  test('extracts and deduplicates stable GitHub attachment URLs', () {
+    const url = 'https://github.com/user-attachments/assets/'
+        '123e4567-e89b-12d3-a456-426614174000';
+
+    expect(
+      parser.stableUrls(['![image]($url)', '<img src="$url">']),
+      [url],
+    );
+  });
+
+  test('ignores temporary and unrelated URLs', () {
+    expect(
+      parser.stableUrls([
+        'https://objects.githubusercontent.com/private/signed?token=short',
+        'https://example.org/image.png',
+      ]),
+      isEmpty,
+    );
+  });
+}

--- a/test/github_service_test.dart
+++ b/test/github_service_test.dart
@@ -52,6 +52,81 @@ void main() {
     expect(issue.url, 'https://github.com/example/wiki/issues/123');
   });
 
+  test('createIssue can keep an image upload issue unlabeled', () async {
+    late http.Request capturedRequest;
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(
+          jsonEncode({
+            'number': 124,
+            'html_url': 'https://github.com/example/wiki/issues/124',
+          }),
+          201,
+        );
+      }),
+    );
+
+    await service.createIssue(
+      title: '[Bild-Quelle]: Diagramm',
+      body: 'pending',
+      labels: const [],
+    );
+
+    final payload = jsonDecode(capturedRequest.body) as Map<String, dynamic>;
+    expect(payload['labels'], isEmpty);
+  });
+
+  test('finalizes an attachment through issue APIs', () async {
+    final requests = <http.Request>[];
+    final service = GitHubService(
+      'secret',
+      owner: 'example',
+      repo: 'wiki',
+      client: MockClient((request) async {
+        requests.add(request);
+        if (request.method == 'GET') {
+          return http.Response(
+            jsonEncode([
+              {
+                'body': '![image](https://github.com/user-attachments/assets/'
+                    '123e4567-e89b-12d3-a456-426614174000)',
+                'created_at': '2026-08-25T18:00:00Z',
+                'user': {'login': 'developer'},
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      }),
+    );
+
+    final comments = await service.listIssueComments(42);
+    await service.updateIssueBody(42, 'final body');
+    await service.addIssueLabel(42, 'quelle');
+    await service.closeIssue(42);
+
+    expect(comments.single.authorLogin, 'developer');
+    expect(requests.map((request) => request.method), [
+      'GET',
+      'PATCH',
+      'POST',
+      'PATCH',
+    ]);
+    expect(
+      jsonDecode(requests[2].body),
+      {'labels': ['quelle']},
+    );
+    expect(
+      jsonDecode(requests[3].body),
+      {'state': 'closed', 'state_reason': 'not_planned'},
+    );
+  });
+
   test('listRecentSourceIssues loads source issues and excludes pull requests',
       () async {
     late http.Request capturedRequest;

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,7 +1,10 @@
+import 'package:developer_wiki_source_capture/models/created_issue.dart';
 import 'package:developer_wiki_source_capture/models/shared_content.dart';
 import 'package:developer_wiki_source_capture/models/image_source_file.dart';
+import 'package:developer_wiki_source_capture/models/pending_image_upload.dart';
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/screens/home_screen.dart';
+import 'package:developer_wiki_source_capture/services/image_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -102,4 +105,61 @@ void main() {
 
     expect(find.text('🖼️ Bild-Quelle:image.png'), findsOneWidget);
   });
+
+  testWidgets('pending image upload remains visible after restart', (
+    tester,
+  ) async {
+    final gateway = _FakeImageUploadGateway(
+      PendingImageUpload(
+        issueNumber: 42,
+        issueUrl: 'https://github.com/example/wiki/issues/42',
+        createdAt: DateTime.utc(2026, 8, 25),
+        title: 'Diagramm',
+        values: const {},
+        image: const ImageSourceFile(
+          path: '/private/image.png',
+          name: 'image.png',
+          mimeType: 'image/png',
+          sizeBytes: 8,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: HomeScreen(imageUploadGateway: gateway)),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('pending-image-upload')), findsOneWidget);
+    expect(find.text('Bild-Upload #42 fortsetzen'), findsOneWidget);
+  });
+}
+
+class _FakeImageUploadGateway implements ImageUploadGateway {
+  _FakeImageUploadGateway(this.pending);
+
+  final PendingImageUpload? pending;
+
+  @override
+  Future<void> discard(PendingImageUpload upload) async {}
+
+  @override
+  Future<PendingImageUpload?> loadPending() async => pending;
+
+  @override
+  Future<void> open(PendingImageUpload upload) async {}
+
+  @override
+  Future<PendingImageUpload> start({
+    required String title,
+    required Map<String, String> values,
+    required ImageSourceFile image,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<CreatedIssue> verify(PendingImageUpload upload) {
+    throw UnimplementedError();
+  }
 }

--- a/test/pending_image_upload_test.dart
+++ b/test/pending_image_upload_test.dart
@@ -1,0 +1,28 @@
+import 'package:developer_wiki_source_capture/models/image_source_file.dart';
+import 'package:developer_wiki_source_capture/models/pending_image_upload.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('pending image upload survives JSON persistence', () {
+    final upload = PendingImageUpload(
+      issueNumber: 42,
+      issueUrl: 'https://github.com/example/wiki/issues/42',
+      createdAt: DateTime.utc(2026, 8, 25, 18),
+      title: 'Diagramm',
+      values: const {'description': 'Systemkontext'},
+      image: const ImageSourceFile(
+        path: '/private/image.png',
+        name: 'image.png',
+        mimeType: 'image/png',
+        sizeBytes: 8,
+      ),
+    );
+
+    final restored = PendingImageUpload.fromJson(upload.toJson());
+
+    expect(restored.issueNumber, 42);
+    expect(restored.values['description'], 'Systemkontext');
+    expect(restored.image.path, '/private/image.png');
+    expect(restored.createdAt, DateTime.utc(2026, 8, 25, 18));
+  });
+}

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
 
 import 'package:developer_wiki_source_capture/models/image_source_file.dart';
+import 'package:developer_wiki_source_capture/models/created_issue.dart';
+import 'package:developer_wiki_source_capture/models/pending_image_upload.dart';
 import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/screens/source_form_screen.dart';
 import 'package:developer_wiki_source_capture/services/image_input_service.dart';
+import 'package:developer_wiki_source_capture/services/image_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -156,9 +159,68 @@ void main() {
 
     expect(find.text('Bitte markierte Pflichtfelder prüfen.'), findsOneWidget);
     expect(
-      find.textContaining('Die Bild-Quelle ist lokal vorbereitet'),
+      find.textContaining('Bild-Upload für Issue'),
       findsNothing,
     );
+  });
+
+  testWidgets('starts and finalizes the two-step GitHub image upload', (
+    tester,
+  ) async {
+    final directory = await Directory.systemTemp.createTemp('image-upload-');
+    addTearDown(() => directory.delete(recursive: true));
+    final file = File('${directory.path}/source.png');
+    await file.writeAsBytes(
+      const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+    );
+    final inputGateway = _FakeImageInputGateway(
+      ImageSourceFile(
+        path: file.path,
+        name: 'source.png',
+        mimeType: 'image/png',
+        sizeBytes: 8,
+      ),
+    );
+    final uploadGateway = _FakeImageUploadGateway();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SourceFormScreen(
+          initialTemplate: imageSourceTemplate,
+          imageInputGateway: inputGateway,
+          imageUploadGateway: uploadGateway,
+        ),
+      ),
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Issue-Titel'),
+      'Architekturdiagramm',
+    );
+    await tester.tap(find.byKey(const Key('image-source-pick-button')));
+    await tester.pumpAndSettle();
+    final saveButton = find.byKey(const Key('source-form-save-button'));
+    await tester.scrollUntilVisible(
+      saveButton,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    await tester.tap(saveButton);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Bild-Upload für Issue #123'), findsOneWidget);
+    expect(uploadGateway.started, isTrue);
+
+    await tester.scrollUntilVisible(
+      saveButton,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(saveButton);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Quelle erstellt – Issue #123'), findsOneWidget);
+    expect(uploadGateway.verified, isTrue);
   });
 }
 
@@ -175,4 +237,41 @@ class _FakeImageInputGateway implements ImageInputGateway {
 
   @override
   Future<ImageSourceFile?> pickImage() async => image;
+}
+
+class _FakeImageUploadGateway implements ImageUploadGateway {
+  bool started = false;
+  bool verified = false;
+
+  @override
+  Future<void> discard(PendingImageUpload upload) async {}
+
+  @override
+  Future<PendingImageUpload?> loadPending() async => null;
+
+  @override
+  Future<void> open(PendingImageUpload upload) async {}
+
+  @override
+  Future<PendingImageUpload> start({
+    required String title,
+    required Map<String, String> values,
+    required ImageSourceFile image,
+  }) async {
+    started = true;
+    return PendingImageUpload(
+      issueNumber: 123,
+      issueUrl: 'https://github.com/example/wiki/issues/123',
+      createdAt: DateTime.utc(2026, 8, 25),
+      title: title,
+      values: values,
+      image: image,
+    );
+  }
+
+  @override
+  Future<CreatedIssue> verify(PendingImageUpload upload) async {
+    verified = true;
+    return CreatedIssue(number: upload.issueNumber, url: upload.issueUrl);
+  }
 }


### PR DESCRIPTION
## Ursache

Die gestapelte PR-Kette wurde zwar vollständig implementiert, aber nicht vollständig bis `master` weitergeführt. `master` enthielt nach den Rebase-/Merge-Schritten bytegenau den Stand nach Android-Bild-Share; der finale GitHub-Attachment-Schritt blieb auf den Story-Branches zurück. Dadurch zeigte die App weiterhin nur den Zwischenzustand „Bild-Quelle ist vorbereitet“.

## Lösung

- neuer Integrationsbranch direkt vom aktuellen `master`
- ein einzelner additiver Commit mit dem bereits implementierten und geprüften vollständigen Zielstand
- unlabeled Pending-Issue für den noch nicht importierbaren Upload-Zustand
- Upload über den offiziellen GitHub-Markdown-Kommentarbereich
- Prüfung genau einer stabilen `user-attachments`-URL aus einem Kommentar des authentifizierten Kontos
- Aktualisierung des Issue-Bodys und anschließendes Labeling mit `quelle`
- verschlüsselte Persistenz, Wiederaufnahme nach App-Neustart und kontrolliertes Verwerfen
- zugehörige API-, Parser-, Persistenz- und Widget-Tests

## Branch-Prüfung

- Basis: aktueller `master` `902184760239f0d8aa842e750d3f814867dcbb7c`
- Branch: genau 1 Commit voraus und 0 Commits zurück
- Diff: exakt die 18 noch fehlenden Dateien des finalen Attachment-Schritts
- Ziel-Tree entspricht bytegenau dem bereits implementierten vollständigen Stack-Stand
- keine Änderung oder Umschreibung bestehender Story-Branches

PR #100 wird durch diesen direkt auf `master` basierenden Konsolidierungs-PR ersetzt.

## Prüfungen

- vollständige Git-Tree-SHAs von `master`, den drei Story-Branches und den ursprünglichen Stack-Commits verglichen
- Branch-/PR-Basen und Merge-Zustände von #96 bis #100 geprüft
- resultierenden Branch erneut über GitHub gegen `master` verglichen: konfliktfreier Ein-Commit-Diff
- Flutter/Dart-Tests konnten in der verfügbaren Umgebung nicht ausgeführt werden, weil dort weder Flutter noch Dart installiert ist

Nach dem Merge bitte lokal entsprechend der Reviewer-Dokumentation ausführen:

```text
flutter clean
dart format --output=none --set-exit-if-changed lib test
flutter analyze
flutter test
flutter run
```

## Dokumentation

`CHANGELOG.md`, `README.md`, `docs/README.md`, `docs/architecture.md` und die neue Datei `docs/image-sources.md` sind Bestandteil des konsolidierten Zielstands.

## Lizenzprüfung

Es werden keine neuen Abhängigkeiten oder Fremd-Assets eingeführt. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #101
Closes #95
Closes #90