### PR TITLE
Hängenden Bildquellen-Widget-Test stabilisieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Fixed
 
+- Bildquellen-Widget-Tests warten zustandsbasiert auf Vorschau-, Pending- und
+  Erfolgszustände, statt bei einem animierten Textcursor mit `pumpAndSettle`
+  bis zum Timeout zu laufen.
 - Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
 - Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
 - Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -27,6 +27,23 @@ Future<void> pumpUntilFound(
   }
 }
 
+Future<void> pumpUntilNotFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 2),
+  Duration step = const Duration(milliseconds: 20),
+}) async {
+  var elapsed = Duration.zero;
+
+  while (finder.evaluate().isNotEmpty) {
+    if (elapsed >= timeout) {
+      throw TestFailure('Widget ist innerhalb von $timeout nicht verschwunden.');
+    }
+    await tester.pump(step);
+    elapsed += step;
+  }
+}
+
 void main() {
   testWidgets('shows a temporary hint when validation fails', (tester) async {
     await tester.pumpWidget(
@@ -123,16 +140,17 @@ void main() {
     );
 
     await tester.tap(find.byKey(const Key('image-source-pick-button')));
-    await tester.pumpAndSettle();
+    final preview = find.byKey(const Key('image-source-preview'));
+    await pumpUntilFound(tester, preview);
 
-    expect(find.byKey(const Key('image-source-preview')), findsOneWidget);
+    expect(preview, findsOneWidget);
     expect(find.textContaining('source.png'), findsOneWidget);
     expect(find.text('Ersetzen'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('image-source-remove-button')));
-    await tester.pumpAndSettle();
+    await pumpUntilNotFound(tester, preview);
 
-    expect(find.byKey(const Key('image-source-preview')), findsNothing);
+    expect(preview, findsNothing);
     expect(gateway.discarded, hasLength(1));
   });
 
@@ -197,7 +215,10 @@ void main() {
       'Architekturdiagramm',
     );
     await tester.tap(find.byKey(const Key('image-source-pick-button')));
-    await tester.pumpAndSettle();
+    await pumpUntilFound(
+      tester,
+      find.byKey(const Key('image-source-preview')),
+    );
     final saveButton = find.byKey(const Key('source-form-save-button'));
     await tester.scrollUntilVisible(
       saveButton,
@@ -206,9 +227,10 @@ void main() {
     );
 
     await tester.tap(saveButton);
-    await tester.pumpAndSettle();
+    final pendingUpload = find.textContaining('Bild-Upload für Issue #123');
+    await pumpUntilFound(tester, pendingUpload);
 
-    expect(find.textContaining('Bild-Upload für Issue #123'), findsOneWidget);
+    expect(pendingUpload, findsOneWidget);
     expect(uploadGateway.started, isTrue);
 
     await tester.scrollUntilVisible(
@@ -217,9 +239,10 @@ void main() {
       scrollable: find.byType(Scrollable).first,
     );
     await tester.tap(saveButton);
-    await tester.pumpAndSettle();
+    final createdIssue = find.textContaining('Quelle erstellt – Issue #123');
+    await pumpUntilFound(tester, createdIssue);
 
-    expect(find.textContaining('Quelle erstellt – Issue #123'), findsOneWidget);
+    expect(createdIssue, findsOneWidget);
     expect(uploadGateway.verified, isTrue);
   });
 }

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -37,7 +37,9 @@ Future<void> pumpUntilNotFound(
 
   while (finder.evaluate().isNotEmpty) {
     if (elapsed >= timeout) {
-      throw TestFailure('Widget ist innerhalb von $timeout nicht verschwunden.');
+      throw TestFailure(
+        'Widget ist innerhalb von $timeout nicht verschwunden.',
+      );
     }
     await tester.pump(step);
     elapsed += step;


### PR DESCRIPTION
## Ursache

Der zweistufige Bildquellen-Test fokussiert mit `tester.enterText(...)` das Titel-`TextFormField`. Dessen blinkender Cursor kann dauerhaft weitere Frames planen. Die anschließend verwendeten `pumpAndSettle()`-Aufrufe warten jedoch auf einen vollständig framefreien Zustand und können deshalb bis zum Test-Timeout laufen, obwohl Vorschau, Pending-Zustand oder Erfolg bereits fachlich erreicht sind.

Es fehlt somit nicht in der Upload-Produktlogik ein erforderliches `await`; die Testsynchronisation wartete auf die falsche Bedingung.

## Lösung

- `pumpAndSettle()` vollständig aus `source_form_screen_test.dart` entfernt
- nach der Bildauswahl gezielt auf die Vorschau gewartet
- nach dem Entfernen gezielt auf das Verschwinden der Vorschau gewartet
- nach Upload-Start gezielt auf die Pending-Karte gewartet
- nach Finalisierung gezielt auf die Erfolgskarte gewartet
- alle Wartehelfer bleiben durch ein Zwei-Sekunden-Timeout begrenzt

## Prüfungen

- Diff gegen aktuellen `master` geprüft: ausschließlich Testdatei und Changelog
- keine Änderung an Widget-, Upload-, GitHub- oder Persistenzlogik
- keine verbleibende Verwendung von `pumpAndSettle()` in `source_form_screen_test.dart`
- Dart-Format der geänderten Abschnitte manuell gegen die Projektkonventionen geprüft
- `flutter test` und `flutter analyze` konnten in der verfügbaren Umgebung nicht ausgeführt werden, weil dort weder Flutter noch Dart installiert ist

## Dokumentation

`CHANGELOG.md` wurde unter `Unreleased / Fixed` ergänzt. README und Architekturdokumentation sind nicht betroffen, weil sich kein Produktverhalten und keine Schnittstelle ändert.

## Lizenzprüfung

Keine neue Abhängigkeit und kein Fremd-Asset. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #103