### PR TITLE
Initiales Share-Intent-Mapping vollständig abwarten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 ### Fixed
 
 - Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
+- Initiale Share-Intent-Inhalte werden innerhalb der vorgesehenen asynchronen
+  Fehlerbehandlung vollständig abgewartet.
 - Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
 - Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
 - Widget-Test stabilisiert nach dem Scrollen die Sichtbarkeit und das Layout des Speichern-Buttons vor dem Tap.

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -31,7 +31,7 @@ class ShareIntentService {
       final initial = await _channel.invokeMapMethod<String, dynamic>(
         'getInitialShare',
       );
-      return _fromMap(initial);
+      return await _fromMap(initial);
     } on MissingPluginException {
       return null;
     }

--- a/test/share_intent_service_test.dart
+++ b/test/share_intent_service_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
+import 'package:developer_wiki_source_capture/models/image_source_file.dart';
 import 'package:developer_wiki_source_capture/models/shared_content.dart';
+import 'package:developer_wiki_source_capture/services/image_validation_service.dart';
 import 'package:developer_wiki_source_capture/services/share_intent_service.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -55,4 +57,29 @@ void main() {
     expect(content?.kind, SharedContentKind.imageError);
     expect(content?.text, 'Datei zu groß');
   });
+
+  test('handles an asynchronous missing plugin error while mapping', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async => {
+              'kind': 'image',
+              'path': '/private/shared.png',
+              'name': 'shared.png',
+              'mimeType': 'image/png',
+              'sizeBytes': 8,
+            });
+
+    final content = await ShareIntentService(
+      channel: channel,
+      validationService: _MissingPluginImageValidationService(),
+    ).initialize((_) {});
+
+    expect(content, isNull);
+  });
+}
+
+class _MissingPluginImageValidationService extends ImageValidationService {
+  @override
+  Future<ImageSourceFile> validate(ImageSourceFile image) async {
+    throw MissingPluginException();
+  }
 }


### PR DESCRIPTION
## Ursache

`ShareIntentService.initialize()` gab `_fromMap(initial)` als Future direkt aus einem `try`-Block zurück. Dadurch entstand eine asynchrone Exception aus dem Mapping erst nach Verlassen dieses Blocks und konnte vom vorhandenen `on MissingPluginException` nicht mehr behandelt werden. Der Analyzer meldete deshalb `unawaited_return_in_try_block`.

## Lösung

- Mapping-Future mit `return await _fromMap(initial)` innerhalb des `try`-Blocks abwarten
- Regressionstest ergänzt, der eine asynchrone `MissingPluginException` während der Bildvalidierung simuliert
- erwartetes Verhalten geprüft: `initialize()` behandelt den Fehler und liefert `null`

## Prüfungen

- Branch basiert direkt auf aktuellem `master` und ist genau einen Commit voraus
- Diff enthält ausschließlich Share-Intent-Service, zugehörigen Test und Changelog
- die gemeldete Analyzer-Stelle enthält nun das erforderliche `await`
- `flutter analyze` und `flutter test` konnten in der verfügbaren Umgebung nicht ausgeführt werden, da weder Flutter noch Dart installiert ist

## Abgrenzung zu #104

Dieser PR behebt ausschließlich den Analyzer-Hinweis und die asynchrone Fehlergrenze im Share-Intent-Service. PR #104 stabilisiert unabhängig davon die Widget-Test-Synchronisation. Beide PRs basieren direkt auf `master`.

## Dokumentation

`CHANGELOG.md` wurde unter `Unreleased / Fixed` ergänzt. README und Architekturdokumentation sind nicht betroffen, da sich keine öffentliche Bedienung oder Schnittstelle ändert.

## Lizenzprüfung

Keine neue Abhängigkeit und kein Fremd-Asset. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #105