### PR TITLE
Vollständige PNG-Testdaten für Bildvorschau verwenden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Fixed
 
+- Bildquellen-Widget-Tests verwenden vollständig decodierbare PNG-Testdaten,
+  damit der Bild-Codec unter Windows nicht an einer abgeschnittenen Datei hängt.
 - Bildquellen-Widget-Tests warten zustandsbasiert auf Vorschau-, Pending- und
   Erfolgszustände, statt bei einem animierten Textcursor mit `pumpAndSettle`
   bis zum Timeout zu laufen.

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:developer_wiki_source_capture/models/image_source_file.dart';
@@ -9,6 +10,10 @@ import 'package:developer_wiki_source_capture/services/image_input_service.dart'
 import 'package:developer_wiki_source_capture/services/image_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+final _validPngBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+);
 
 Future<void> pumpUntilFound(
   WidgetTester tester,
@@ -120,9 +125,7 @@ void main() {
     final directory = await Directory.systemTemp.createTemp('image-form-');
     addTearDown(() => directory.delete(recursive: true));
     final file = File('${directory.path}/source.png');
-    await file.writeAsBytes(
-      const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
-    );
+    await file.writeAsBytes(_validPngBytes);
     final gateway = _FakeImageInputGateway(
       ImageSourceFile(
         path: file.path,
@@ -190,9 +193,7 @@ void main() {
     final directory = await Directory.systemTemp.createTemp('image-upload-');
     addTearDown(() => directory.delete(recursive: true));
     final file = File('${directory.path}/source.png');
-    await file.writeAsBytes(
-      const [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
-    );
+    await file.writeAsBytes(_validPngBytes);
     final inputGateway = _FakeImageInputGateway(
       ImageSourceFile(
         path: file.path,


### PR DESCRIPTION
## Ursache

Der weiterhin hängende Test erzeugte als vermeintliche PNG-Datei ausschließlich die acht Byte lange PNG-Signatur. Die Vorschau reicht diese abgeschnittene Datei an `Image.file` und damit an den asynchronen Flutter-Bild-Codec weiter. Unter Windows kann bereits `tester.pump(...)` auf diese unvollständige Dekodierung warten; deshalb konnte auch der in #103 ergänzte zustandsbasierte Zwei-Sekunden-Timeout nicht greifen.

## Lösung

- kleine, vollständig decodierbare 1×1-PNG-Testdatei als gemeinsame Testfixture ergänzt
- beide Bildquellen-Widget-Tests auf diese gültigen Bilddaten umgestellt
- zustandsbasierte Wartehelfer aus #103 unverändert beibehalten

## Prüfung

- Branch basiert direkt auf aktuellem `master`
- Änderung betrifft ausschließlich `test/source_form_screen_test.dart` und `CHANGELOG.md`
- die eingebetteten Bytes wurden als gültiges PNG (1×1 Pixel, Gray+Alpha) geprüft
- `flutter test` und `flutter analyze` können in der verfügbaren Umgebung nicht ausgeführt werden, weil Flutter und Dart dort nicht installiert sind

## Lizenzprüfung

Die PNG-Daten sind eine rein technische, eingebettete Testfixture und werden nicht mit dem Produkt ausgeliefert. Es gibt keine neue Abhängigkeit und kein Fremd-Asset; `ATTRIBUTIONS.md` bleibt unverändert und die MIT-Lizenz kann beibehalten werden.

Closes #107