### PR TITLE
Bildvorschau-Widget-Tests vom nativen Codec entkoppeln

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Fixed
 
+- Bildquellen-Widget-Tests verwenden eine injizierte synchrone Vorschau und
+  hängen damit weder vom nativen Bild-Codec noch vom Windows-Dateisystem ab.
 - Bildquellen-Widget-Tests verwenden vollständig decodierbare PNG-Testdaten,
   damit der Bild-Codec unter Windows nicht an einer abgeschnittenen Datei hängt.
 - Bildquellen-Widget-Tests warten zustandsbasiert auf Vorschau-, Pending- und

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -24,6 +24,7 @@ class SourceFormScreen extends StatefulWidget {
     this.sharedContent,
     this.imageInputGateway,
     this.imageUploadGateway,
+    this.imagePreviewBuilder,
     this.pendingUpload,
   });
 
@@ -31,6 +32,7 @@ class SourceFormScreen extends StatefulWidget {
   final SharedContent? sharedContent;
   final ImageInputGateway? imageInputGateway;
   final ImageUploadGateway? imageUploadGateway;
+  final Widget Function(ImageSourceFile image)? imagePreviewBuilder;
   final PendingImageUpload? pendingUpload;
 
   @override
@@ -630,13 +632,14 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
                     key: const Key('image-source-preview'),
                     width: double.infinity,
                     height: 220,
-                    child: Image.file(
-                      File(image.path),
-                      fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => const Center(
-                        child: Text('Bildvorschau nicht verfügbar'),
-                      ),
-                    ),
+                    child: widget.imagePreviewBuilder?.call(image) ??
+                        Image.file(
+                          File(image.path),
+                          fit: BoxFit.contain,
+                          errorBuilder: (_, __, ___) => const Center(
+                            child: Text('Bildvorschau nicht verfügbar'),
+                          ),
+                        ),
                   ),
                 ),
               ),

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:developer_wiki_source_capture/models/image_source_file.dart';
 import 'package:developer_wiki_source_capture/models/created_issue.dart';
 import 'package:developer_wiki_source_capture/models/pending_image_upload.dart';
@@ -10,10 +7,6 @@ import 'package:developer_wiki_source_capture/services/image_input_service.dart'
 import 'package:developer_wiki_source_capture/services/image_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-final _validPngBytes = base64Decode(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-);
 
 Future<void> pumpUntilFound(
   WidgetTester tester,
@@ -122,13 +115,9 @@ void main() {
   testWidgets('shows, replaces and removes an image source preview', (
     tester,
   ) async {
-    final directory = await Directory.systemTemp.createTemp('image-form-');
-    addTearDown(() => directory.delete(recursive: true));
-    final file = File('${directory.path}/source.png');
-    await file.writeAsBytes(_validPngBytes);
     final gateway = _FakeImageInputGateway(
       ImageSourceFile(
-        path: file.path,
+        path: 'source.png',
         name: 'source.png',
         mimeType: 'image/png',
         sizeBytes: 8,
@@ -140,6 +129,9 @@ void main() {
         home: SourceFormScreen(
           initialTemplate: imageSourceTemplate,
           imageInputGateway: gateway,
+          imagePreviewBuilder: (_) => const ColoredBox(
+            color: Colors.transparent,
+          ),
         ),
       ),
     );
@@ -190,13 +182,9 @@ void main() {
   testWidgets('starts and finalizes the two-step GitHub image upload', (
     tester,
   ) async {
-    final directory = await Directory.systemTemp.createTemp('image-upload-');
-    addTearDown(() => directory.delete(recursive: true));
-    final file = File('${directory.path}/source.png');
-    await file.writeAsBytes(_validPngBytes);
     final inputGateway = _FakeImageInputGateway(
       ImageSourceFile(
-        path: file.path,
+        path: 'source.png',
         name: 'source.png',
         mimeType: 'image/png',
         sizeBytes: 8,
@@ -210,6 +198,9 @@ void main() {
           initialTemplate: imageSourceTemplate,
           imageInputGateway: inputGateway,
           imageUploadGateway: uploadGateway,
+          imagePreviewBuilder: (_) => const ColoredBox(
+            color: Colors.transparent,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Befund aus dem erneuten Windows-Test

Der Test hängt auch mit einer vollständigen PNG-Datei. Die nach `Ctrl+C` sichtbare `PathNotFoundException` entsteht in `FlutterPlatform._startTest.finalize` beim parallelen Aufräumen des bereits abgebrochenen Test-Listeners. Sie ist eine Abbruchfolge, nicht die Ursache des ursprünglichen Hängers.

Der verbleibende problematische Anteil ist die echte `Image.file`-Dekodierung innerhalb des Widget-Tests. Hängt ein nativer Codec-Aufruf in `tester.pump()`, kann auch ein außen liegender pump-basierter Timeout nicht fortschreiten.

## Lösung

- optionalen `imagePreviewBuilder` als Test-Naht am `SourceFormScreen` ergänzt
- ohne Injection bleibt das Produktverhalten unverändert und verwendet weiterhin `Image.file`
- beide Bildquellen-Widget-Tests verwenden eine synchrone `ColoredBox` als Vorschau
- temporäre Dateien, PNG-Dekodierung und Windows-Dateisystemzugriffe vollständig aus diesen Widget-Tests entfernt
- Auswahl, sichtbare Vorschau, Entfernen und zweistufiger Upload bleiben weiterhin abgedeckt

## Prüfung

- Branch basiert direkt auf aktuellem `master` nach Merge von #108
- genau ein Commit und drei betroffene Dateien
- Produktpfad behält Dateivorschau samt bestehendem Fehlerzustand bei
- Tests greifen nicht mehr auf `Directory.systemTemp`, `File` oder den Bild-Codec zu
- `flutter test` und `flutter analyze` können in der verfügbaren Umgebung nicht ausgeführt werden, weil Flutter und Dart dort nicht installiert sind

## Dokumentation und Lizenz

`CHANGELOG.md` ist ergänzt. Es gibt keine neue Abhängigkeit und kein Fremd-Asset; `ATTRIBUTIONS.md` bleibt unverändert und die MIT-Lizenz kann beibehalten werden.

Closes #109