### PR TITLE
Gesrollte Bildquellen-Aktionen zuverlässig antippen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Fixed
 
+- Bildquellen-Widget-Tests machen gescrollte Aktionsbuttons vor dem Tap
+  vollständig sichtbar und pumpen anschließend das aktualisierte Layout.
 - Bildquellen-Widget-Tests verwenden eine injizierte synchrone Vorschau und
   hängen damit weder vom nativen Bild-Codec noch vom Windows-Dateisystem ab.
 - Bildquellen-Widget-Tests verwenden vollständig decodierbare PNG-Testdaten,

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -144,7 +144,10 @@ void main() {
     expect(find.textContaining('source.png'), findsOneWidget);
     expect(find.text('Ersetzen'), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('image-source-remove-button')));
+    final removeButton = find.byKey(const Key('image-source-remove-button'));
+    await tester.ensureVisible(removeButton);
+    await tester.pump();
+    await tester.tap(removeButton);
     await pumpUntilNotFound(tester, preview);
 
     expect(preview, findsNothing);
@@ -169,6 +172,8 @@ void main() {
       300,
       scrollable: find.byType(Scrollable).first,
     );
+    await tester.ensureVisible(saveButton);
+    await tester.pump();
     await tester.tap(saveButton);
     await tester.pump();
 
@@ -219,7 +224,8 @@ void main() {
       300,
       scrollable: find.byType(Scrollable).first,
     );
-
+    await tester.ensureVisible(saveButton);
+    await tester.pump();
     await tester.tap(saveButton);
     final pendingUpload = find.textContaining('Bild-Upload für Issue #123');
     await pumpUntilFound(tester, pendingUpload);
@@ -232,6 +238,8 @@ void main() {
       300,
       scrollable: find.byType(Scrollable).first,
     );
+    await tester.ensureVisible(saveButton);
+    await tester.pump();
     await tester.tap(saveButton);
     final createdIssue = find.textContaining('Quelle erstellt – Issue #123');
     await pumpUntilFound(tester, createdIssue);


### PR DESCRIPTION
## Befund aus dem Windows-Test

Der Testlauf hängt nach #110 nicht mehr und endet regulär. Zwei Tests schlagen jedoch fehl, weil `tester.tap(...)` laut Flutter-Warnung das Ziel verfehlt. Dadurch wird die Aktion nicht ausgelöst und der anschließende zustandsbasierte Wartehelfer meldet nach zwei Sekunden korrekt, dass der erwartete Zustand fehlt.

## Lösung

- Entfernen-Button vor dem Tap mit `ensureVisible` vollständig in den Viewport holen
- Speichern-Button im Test ohne Bild vor dem Tap zusätzlich stabilisieren
- Speichern-Button vor beiden Schritten des zweistufigen Uploads vollständig sichtbar machen
- nach jedem `ensureVisible` einen Frame pumpen, damit Hit-Test-Geometrie und Layout aktuell sind

## Prüfung

- Branch basiert direkt auf aktuellem `master` nach Merge von #110
- Änderung betrifft ausschließlich Widget-Test und Changelog
- bestehendes, bereits funktionierendes Muster des Snackbar-Tests wird konsistent wiederverwendet
- keine Änderung am Produktverhalten
- `flutter test` und `flutter analyze` können in der verfügbaren Umgebung nicht ausgeführt werden, weil Flutter und Dart dort nicht installiert sind

## Lizenzprüfung

Keine neue Abhängigkeit und kein Fremd-Asset. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #111