### PR TITLE
Zu lazy aufgebauten Upload-Statuskarten scrollen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Fixed
 
+- Der zweistufige Upload-Widget-Test scrollt zu lazy aufgebauten Pending- und
+  Erfolgskarten, bevor er deren Darstellung prüft.
 - Bildquellen-Widget-Tests machen gescrollte Aktionsbuttons vor dem Tap
   vollständig sichtbar und pumpen anschließend das aktualisierte Layout.
 - Bildquellen-Widget-Tests verwenden eine injizierte synchrone Vorschau und

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -227,11 +227,17 @@ void main() {
     await tester.ensureVisible(saveButton);
     await tester.pump();
     await tester.tap(saveButton);
+    await tester.pump();
+    expect(uploadGateway.started, isTrue);
+
     final pendingUpload = find.textContaining('Bild-Upload für Issue #123');
-    await pumpUntilFound(tester, pendingUpload);
+    await tester.scrollUntilVisible(
+      pendingUpload,
+      -300,
+      scrollable: find.byType(Scrollable).first,
+    );
 
     expect(pendingUpload, findsOneWidget);
-    expect(uploadGateway.started, isTrue);
 
     await tester.scrollUntilVisible(
       saveButton,
@@ -241,11 +247,17 @@ void main() {
     await tester.ensureVisible(saveButton);
     await tester.pump();
     await tester.tap(saveButton);
+    await tester.pump();
+    expect(uploadGateway.verified, isTrue);
+
     final createdIssue = find.textContaining('Quelle erstellt – Issue #123');
-    await pumpUntilFound(tester, createdIssue);
+    await tester.scrollUntilVisible(
+      createdIssue,
+      -300,
+      scrollable: find.byType(Scrollable).first,
+    );
 
     expect(createdIssue, findsOneWidget);
-    expect(uploadGateway.verified, isTrue);
   });
 }
 


### PR DESCRIPTION
## Befund aus dem erneuten Windows-Test

Nach #112 laufen 37 Tests erfolgreich; nur der zweistufige Upload-Test schlägt noch fehl. Es gibt keine Tap-Warnung mehr. Der Finder wartet stattdessen auf die Pending-Karte, während die `ListView` unten beim Speichern-Button steht.

Pending- und Erfolgskarte werden nahe dem Formularanfang eingefügt. Da die `ListView` ihre Kinder lazy aufbaut, existieren diese außerhalb des aktuellen Viewports noch nicht im Widget-Baum. Ein reiner Pump-/Finder-Loop kann sie daher nicht entdecken.

## Lösung

- nach dem ersten Tap und Pump zuerst verifizieren, dass `start()` am Fake-Gateway aufgerufen wurde
- anschließend gezielt nach oben zur Pending-Karte scrollen und ihre Darstellung prüfen
- nach dem zweiten Tap und Pump zuerst verifizieren, dass `verify()` aufgerufen wurde
- anschließend gezielt nach oben zur Erfolgskarte scrollen und ihre Darstellung prüfen

## Prüfung

- Branch basiert direkt auf aktuellem `master` nach Merge von #112
- Änderung betrifft ausschließlich Widget-Test und Changelog
- Produktverhalten bleibt unverändert
- `flutter test` und `flutter analyze` können in der verfügbaren Umgebung nicht ausgeführt werden, weil Flutter und Dart dort nicht installiert sind

## Lizenzprüfung

Keine neue Abhängigkeit und kein Fremd-Asset. `ATTRIBUTIONS.md` bleibt unverändert; die MIT-Lizenz kann beibehalten werden.

Closes #113