### PR TITLE
Teilen-Ziele durch Logo-Overlays unterscheiden

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -14,6 +14,8 @@ steht unter der in der Root-Datei [`LICENSE`](LICENSE) genannten MIT-Lizenz.
   `android/app/src/main/res/mipmap-*`
 - das daraus abgeleitete monochrome Android-Icon
   `android/app/src/main/res/drawable/ic_launcher_monochrome.xml`
+- die daraus abgeleiteten Android-Icons der Teilen-Ziele
+  `android/app/src/main/res/drawable/ic_share_*.xml`
 
 **Entstehung:** Gestaltung, Auswahl und Veröffentlichung durch
 [Huluvu424242](https://github.com/Huluvu424242) unter Verwendung der

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Changed
 
+- Android-Teilen-Ziele verwenden unterscheidbare App-Logo-Varianten mit
+  Weltkugel-, Text- beziehungsweise Bild-Overlay.
 - README nach der Struktur von Standard Readme neu gegliedert und mit der weiterführenden Dokumentation verknüpft.
 - Quellenformular ergonomischer gestaltet: zusätzlicher Abstand unter dem Speichern-Button, temporärer Validierungshinweis und Löschaktionen für befüllte Eingabefelder.
 - Android-Release-Prozess um produktive `release/<tagname>`-Wartungsbranches für Bugfixes, Security Updates und Lifecycle-Maßnahmen ergänzt.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
             android:name=".ShareLinkActivity"
             android:targetActivity=".MainActivity"
             android:exported="true"
+            android:icon="@drawable/ic_share_link"
             android:label="Developer Wiki – Link">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
@@ -22,6 +23,7 @@
             android:name=".ShareTextActivity"
             android:targetActivity=".MainActivity"
             android:exported="true"
+            android:icon="@drawable/ic_share_text"
             android:label="Developer Wiki – Text">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
@@ -33,6 +35,7 @@
             android:name=".ShareImageActivity"
             android:targetActivity=".MainActivity"
             android:exported="true"
+            android:icon="@drawable/ic_share_image"
             android:label="Developer Wiki – Bild">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/android/app/src/main/res/drawable/ic_share_image.xml
+++ b/android/app/src/main/res/drawable/ic_share_image.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M54,82 L54,36 C43,27 31,23 18,24 L18,70 C31,70 43,74 54,82 Z M54,82 L54,36 C65,27 77,23 90,24 L90,70 C77,70 65,74 54,82 Z"
+        android:strokeColor="#1237A6"
+        android:strokeLineJoin="round"
+        android:strokeWidth="5" />
+    <path
+        android:fillColor="#1237A6"
+        android:pathData="M11,35 L38,35 Q42,35 42,39 L42,55 Q42,59 38,59 L11,59 Q7,59 7,55 L7,39 Q7,35 11,35 Z" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M38,43 L59,43 L59,37 L70,47 L59,57 L59,51 L38,51 Z" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M72,48 L84,36 M72,48 L87,48 M72,48 L82,62"
+        android:strokeColor="#1237A6"
+        android:strokeLineCap="round"
+        android:strokeWidth="5" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M66,48 A6,6 0,1 0,78 48 A6,6 0,1 0,66 48 M80,34 A5,5 0,1 0,90 34 A5,5 0,1 0,80 34 M84,48 A5,5 0,1 0,94 48 A5,5 0,1 0,84 48 M78,64 A5,5 0,1 0,88 64 A5,5 0,1 0,78 64" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M68,24 A16,16 0,1 0,100 24 A16,16 0,1 0,68 24"
+        android:strokeColor="#1237A6"
+        android:strokeWidth="2.5" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M74,17 L94,17 L94,31 L74,31 Z M76,29 L81,23 L84.5,27 L88,22.5 L92,29"
+        android:strokeColor="#1565C0"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.8" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M88,19.5 A2,2 0,1 0,92 19.5 A2,2 0,1 0,88 19.5" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_share_link.xml
+++ b/android/app/src/main/res/drawable/ic_share_link.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M54,82 L54,36 C43,27 31,23 18,24 L18,70 C31,70 43,74 54,82 Z M54,82 L54,36 C65,27 77,23 90,24 L90,70 C77,70 65,74 54,82 Z"
+        android:strokeColor="#1237A6"
+        android:strokeLineJoin="round"
+        android:strokeWidth="5" />
+    <path
+        android:fillColor="#1237A6"
+        android:pathData="M11,35 L38,35 Q42,35 42,39 L42,55 Q42,59 38,59 L11,59 Q7,59 7,55 L7,39 Q7,35 11,35 Z" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M38,43 L59,43 L59,37 L70,47 L59,57 L59,51 L38,51 Z" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M72,48 L84,36 M72,48 L87,48 M72,48 L82,62"
+        android:strokeColor="#1237A6"
+        android:strokeLineCap="round"
+        android:strokeWidth="5" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M66,48 A6,6 0,1 0,78 48 A6,6 0,1 0,66 48 M80,34 A5,5 0,1 0,90 34 A5,5 0,1 0,80 34 M84,48 A5,5 0,1 0,94 48 A5,5 0,1 0,84 48 M78,64 A5,5 0,1 0,88 64 A5,5 0,1 0,78 64" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M68,24 A16,16 0,1 0,100 24 A16,16 0,1 0,68 24"
+        android:strokeColor="#1237A6"
+        android:strokeWidth="2.5" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M74,24 A10,10 0,1 0,94 24 A10,10 0,1 0,74 24 M84,14 C79,19 79,29 84,34 M84,14 C89,19 89,29 84,34 M74,24 L94,24 M76,19 C81,21 87,21 92,19 M76,29 C81,27 87,27 92,29"
+        android:strokeColor="#1565C0"
+        android:strokeLineCap="round"
+        android:strokeWidth="1.8" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_share_text.xml
+++ b/android/app/src/main/res/drawable/ic_share_text.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M54,82 L54,36 C43,27 31,23 18,24 L18,70 C31,70 43,74 54,82 Z M54,82 L54,36 C65,27 77,23 90,24 L90,70 C77,70 65,74 54,82 Z"
+        android:strokeColor="#1237A6"
+        android:strokeLineJoin="round"
+        android:strokeWidth="5" />
+    <path
+        android:fillColor="#1237A6"
+        android:pathData="M11,35 L38,35 Q42,35 42,39 L42,55 Q42,59 38,59 L11,59 Q7,59 7,55 L7,39 Q7,35 11,35 Z" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M38,43 L59,43 L59,37 L70,47 L59,57 L59,51 L38,51 Z" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M72,48 L84,36 M72,48 L87,48 M72,48 L82,62"
+        android:strokeColor="#1237A6"
+        android:strokeLineCap="round"
+        android:strokeWidth="5" />
+    <path
+        android:fillColor="#00A99D"
+        android:pathData="M66,48 A6,6 0,1 0,78 48 A6,6 0,1 0,66 48 M80,34 A5,5 0,1 0,90 34 A5,5 0,1 0,80 34 M84,48 A5,5 0,1 0,94 48 A5,5 0,1 0,84 48 M78,64 A5,5 0,1 0,88 64 A5,5 0,1 0,78 64" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M68,24 A16,16 0,1 0,100 24 A16,16 0,1 0,68 24"
+        android:strokeColor="#1237A6"
+        android:strokeWidth="2.5" />
+    <path
+        android:fillColor="#1237A6"
+        android:pathData="M74,16 L94,16 L94,20 L86.5,20 L86.5,33 L81.5,33 L81.5,20 L74,20 Z" />
+</vector>

--- a/test/share_target_icons_test.dart
+++ b/test/share_target_icons_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('share targets reference their distinct overlay icons', () {
+    final manifest = File(
+      'android/app/src/main/AndroidManifest.xml',
+    ).readAsStringSync();
+
+    expect(
+      manifest,
+      contains('android:name=".ShareLinkActivity"'),
+    );
+    expect(manifest, contains('android:icon="@drawable/ic_share_link"'));
+    expect(manifest, contains('android:icon="@drawable/ic_share_text"'));
+    expect(manifest, contains('android:icon="@drawable/ic_share_image"'));
+
+    for (final icon in ['link', 'text', 'image']) {
+      final drawable = File(
+        'android/app/src/main/res/drawable/ic_share_$icon.xml',
+      );
+      expect(drawable.existsSync(), isTrue);
+      expect(drawable.readAsStringSync(), contains('<vector'));
+    }
+  });
+}


### PR DESCRIPTION
## Umsetzung

Die drei Android-Teilen-Ziele verwenden jetzt eine gemeinsame Icon-Familie auf Basis des Developer-Wiki-App-Logos. Oben rechts liegt jeweils ein weißes, blau umrandetes Badge im Stil eines Eclipse-Overlays:

- **Link:** stilisierte Weltkugel mit Breiten- und Längengraden
- **Text:** kräftiges großes `T`
- **Bild:** Bildrahmen mit Berglinie und Sonne

Die Motive unterscheiden sich durch ihre Form und nicht ausschließlich durch Farbe. Das normale Launcher-Icon bleibt unverändert.

## Technische Umsetzung

- drei skalierbare Android-Vector-Drawables für alle Displaydichten ergänzt
- jedem `activity-alias` im AndroidManifest sein eigenes Icon zugeordnet
- automatisierten Test für Manifest-Referenzen und vorhandene Vector-Drawables ergänzt

## Prüfungen

- alle vier geänderten Android-XML-Dateien erfolgreich als wohlgeformtes XML geparst
- Branch basiert direkt auf aktuellem `master` und enthält genau einen Commit
- Diff umfasst ausschließlich die drei Icons, Manifest, Test, Changelog und Attributionen
- `flutter test`, `flutter analyze` und ein Android-Build konnten in der verfügbaren Umgebung nicht ausgeführt werden, weil Flutter, Dart und das Android-SDK dort nicht installiert sind

## Dokumentation

- `CHANGELOG.md` unter `Unreleased / Changed` ergänzt
- `ATTRIBUTIONS.md` um die abgeleiteten Teilen-Ziel-Icons erweitert
- README und Architekturdokumentation bleiben unverändert, da Bedienablauf, Architektur und Schnittstellen unverändert bleiben

## Lizenzprüfung

Die drei Icons sind eigene Ableitungen des bereits unter CC0 1.0 dokumentierten App-Logos. Es wurden keine fremden Motive, Schriften, Bibliotheken oder sonstigen Assets aufgenommen. Die Herkunft ist in `ATTRIBUTIONS.md` ergänzt; die MIT-Lizenz des Projektcodes kann unverändert beibehalten werden.

Closes #115