### PR TITLE
Release 0.1.0+3 vorbereiten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.1.0+3] - 2026-08-25
+
 ### Added
 
 - Grundlage für Bild-Quellen mit eigenem Quellentyp, validierter Bildauswahl,
@@ -54,4 +56,5 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 - Pflichtfelder werden beim Speichern unabhängig von ihrer aktuellen Sichtbarkeit im scrollbaren Quellenformular geprüft.
 - Snackbar-Widget-Test prüft nur den globalen Validierungshinweis und setzt keine gleichzeitig sichtbaren Inline-Feldfehler voraus.
 
-[Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+3...HEAD
+[0.1.0+3]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+2...v0.1.0+3

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         applicationId = "de.huluvu.developer_wiki_source_capture"
         minSdk = 23
         targetSdk = 35
-        versionCode = 1
+        versionCode = 3
         versionName = "0.1.0"
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: developer_wiki_source_capture
 description: Android-App zur strukturierten Erfassung von Quellen-Issues im Developer-Wiki.
 publish_to: none
-version: 0.1.0+2
+version: 0.1.0+3
 environment:
   sdk: '>=3.4.0 <4.0.0'
 dependencies:


### PR DESCRIPTION
## Zusammenfassung

- Flutter-Paketversion auf `0.1.0+3` angehoben
- Android-Standardkonfiguration auf `versionCode = 3` / `versionName = "0.1.0"` abgeglichen
- bisherigen Unreleased-Changelog als `0.1.0+3` vom 25.08.2026 abgeschlossen und Vergleichslinks aktualisiert

## Prüfung

- Versionswerte und Changelog-Inhalte auf dem Release-Branch statisch gegengeprüft
- Branch liegt 3 Commits vor und 0 Commits hinter `master`
- keine Abhängigkeiten, Bibliotheken oder Fremdassets geändert; MIT bleibt erhalten und `ATTRIBUTIONS.md` benötigt keinen neuen Eintrag
- Flutter-Tests nicht erneut ausgeführt, da ausschließlich Versions- und Changelog-Dateien geändert wurden

## Nach dem Merge

Den bestehenden Android-Release-Workflow mit `release_version=0.1.0+3` starten. Dieser PR erzeugt selbst weder Tag noch GitHub Release.

Closes #117