### PR TITLE
feat: UX- und Barrierefreiheitsrichtlinien appweit umsetzen

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.md
@@ -1,0 +1,21 @@
+---
+name: App-Bugreport
+about: Einen aus der Developer-Wiki-App vorbereiteten Fehler melden
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+<!--
+Dieser Inhalt wird von der App mit Fehlerart, Nutzungskontext,
+Releaseversion und Beschreibung vorausgefüllt. Bitte keine PATs,
+Passwörter oder anderen Zugangsdaten eintragen.
+-->
+
+## Fehlerart
+
+## Kontext
+
+## Releaseversion
+
+## Beschreibung

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Added
+
+- Appweites Menü mit About-Dialog, installierter Release- und Buildnummer sowie offline verfügbarer Barrierefreiheitserklärung.
+- Sicherer, kontextbezogener Bugreport für alle Screens und App-Dialoge, der ohne Wiki-PAT ein vorbereitetes Issue mit dem Label `bug` im Browser öffnet.
+- Fehlersammler mit Feldnavigation und Fokussteuerung für Quellenformular, Einstellungen und Bugreport.
+- Fachliche Maximallängen und barrierefreie Restzeichenzähler für alle Texteingaben mit kombinierter sichtbarer, semantischer und akustischer Grenzrückmeldung.
+
+### Changed
+
+- Einstellungen verwenden jetzt feldnahe Validierung, temporäre Hinweise und reservierten Platz unter den Aktionsschaltflächen.
+
 ## [0.1.0+3] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Zusätzliche Account Permissions sind für den aktuellen Funktionsumfang nicht e
 
 Release-Keystores und daraus erzeugte Base64-Dateien dürfen ebenfalls nicht ins Repository eingecheckt werden.
 
+Der App-Bugreport öffnet ausschließlich eine vorbereitete GitHub-Seite im Browser. Das für das persönliche Wiki gespeicherte PAT wird dabei weder gelesen noch für Zugriffe auf das App-Repository verwendet.
+
 ## Hintergrund
 
 Die App ist ein Client des persönlichen Developer-Wikis. Sie übernimmt die mobile Erfassung und GitHub-Interaktion; Importlogik, Archivierung und Wissensaufbereitung verbleiben im Wiki-Repository.
@@ -45,7 +47,11 @@ Der aktuelle Funktionsumfang umfasst unter anderem:
 - Start und Statusabfrage des konfigurierten GitHub-Actions-Workflows,
 - geschützte lokale Speicherung der Konfiguration,
 - Android-Share mit getrennten Zielen für Links, Text und Bilder als
-  zusätzlicher Einstieg in dieselbe Quellenerfassung.
+  zusätzlicher Einstieg in dieselbe Quellenerfassung,
+- appweites Menü mit About, installierter Releaseversion, offline verfügbarer
+  Barrierefreiheitserklärung und kontextbezogenem Bugreport,
+- feldnahe Validierungsfehler mit zusätzlichem Fehlersammler sowie
+  barrierefreie Restzeichenzähler an allen Texteingaben.
 
 Die Quellenformulare sind derzeit versioniert in `lib/models/source_template.dart` enthalten. Dadurch bleibt die App offline startbar und externe Template-Änderungen beeinflussen UI und Requests nicht ungeprüft. Eine spätere Version kann Templates lesend aus dem Wiki laden und eine geprüfte lokale Fallback-Version behalten.
 
@@ -88,6 +94,7 @@ Ablauf und die technische Begründung stehen in der
 Die weiterführende Projektdokumentation liegt unter [`docs/`](docs/README.md):
 
 - [Architektur nach dem C4-Modell](docs/architecture.md)
+- [Barrierefreiheit und UX](docs/accessibility.md)
 - [App-Logo und Launcher-Icons](docs/app-icon.md)
 - [Signierter Android-Release über GitHub Actions](docs/android-release.md)
 - [Bild-Quellen und GitHub-Attachments](docs/image-sources.md)

--- a/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/huluvu/developer_wiki_source_capture/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         configureExternalUrlChannel(flutterEngine)
+        configureAppInfoChannel(flutterEngine)
         configureShareChannel(flutterEngine)
         configureImageChannel(flutterEngine)
     }
@@ -63,6 +64,36 @@ class MainActivity : FlutterActivity() {
             pendingShare = sharedContent
         } else {
             channel.invokeMethod("shared", sharedContent)
+        }
+    }
+
+    private fun configureAppInfoChannel(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "developer_wiki/app_info"
+        ).setMethodCallHandler { call, result ->
+            if (call.method != "getAppInfo") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+            try {
+                @Suppress("DEPRECATION")
+                val packageInfo = packageManager.getPackageInfo(packageName, 0)
+                val buildNumber = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    packageInfo.longVersionCode.toString()
+                } else {
+                    @Suppress("DEPRECATION")
+                    packageInfo.versionCode.toString()
+                }
+                result.success(
+                    mapOf(
+                        "version" to packageInfo.versionName.orEmpty(),
+                        "buildNumber" to buildNumber
+                    )
+                )
+            } catch (error: Exception) {
+                result.error("app_info_failed", error.message, null)
+            }
         }
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Diese Dokumentation ergänzt die kompakte Projektübersicht in der Root-`README.
 ## Inhalt
 
 - [Architektur](architecture.md) – Systemkontext und Container-Sicht nach dem C4-Modell.
+- [Barrierefreiheit und UX](accessibility.md) – App-Menü, Fehlersammler, Zeichenzähler, About und sicherer Bugreport.
 - [App-Logo und Launcher-Icons](app-icon.md) – Masterdatei, Android-Ressourcen und reproduzierbare Ableitung.
 - [Android-Release](android-release.md) – reproduzierbarer, signierter APK-Release über GitHub Actions.
 - [Bild-Quellen und GitHub-Attachments](image-sources.md) – Eingänge,

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,58 @@
+# Barrierefreiheit und UX
+
+Die Developer-Wiki-App setzt die verbindlichen UX- und
+Barrierefreiheitsregeln aus der [AGENTS.md](../AGENTS.md) über gemeinsame,
+wiederverwendbare Komponenten um.
+
+## In der App verfügbare Hilfen
+
+- Ein gemeinsames App-Menü bietet auf allen Screens **Bug melden** und **Über**.
+- Der About-Dialog zeigt Releaseversion und Buildnummer der installierten App.
+- Die Barrierefreiheitserklärung ist offline in der App verfügbar.
+- Validierte Formulare zeigen Fehler direkt am Feld und zusätzlich in einem
+  Fehlersammler am Anfang des Formulars.
+- Ein Eintrag im Fehlersammler scrollt zum betroffenen Feld und setzt den Fokus.
+- Nach fehlgeschlagener Validierung werden Snackbar, Fehlersammler und
+  Fokuswechsel gemeinsam ausgelöst.
+- Textfelder besitzen fachliche Maximallängen. Ab zehn verbleibenden Zeichen
+  erscheint ein sichtbarer und semantischer Restzeichenzähler.
+- Beim Erreichen einer Zeichengrenze werden eine sichtbare Meldung, eine
+  Screenreader-Ansage und ein akustisches Signal kombiniert.
+- Unter primären Aktionsbereichen bleibt Platz für Safe Area, Snackbars und
+  andere temporäre Meldungen.
+
+## Bugreports
+
+Der Bugreport erfasst Fehlerart, optionalen Freitext, aktuellen Screen oder
+Dialog sowie Releaseversion. Danach öffnet die App einen vorbereiteten
+GitHub-Bugreport im Browser:
+
+`https://github.com/Huluvu424242/developer-wiki-app/issues/new`
+
+Der Nutzer kann die Meldung auf GitHub prüfen und endgültig absenden. Das in
+der App gespeicherte PAT des persönlichen Developer-Wikis wird dafür weder
+gelesen noch übertragen. Der Browserablauf setzt das Label `bug` über die
+vorbereitete GitHub-URL.
+
+Keine Logs, Tokens oder anderen Diagnosedaten werden automatisch beigefügt.
+
+## Laufzeitermittlung der Version
+
+Flutter liest Releaseversion und Buildnummer über den Android-MethodChannel
+`developer_wiki/app_info`. Android liefert dafür die tatsächlich
+installierten Paketinformationen. Der Zugriff ist hinter `AppInfoGateway`
+gekapselt und kann in Widget-Tests durch einen Fake ersetzt werden.
+
+## Pflege der Barrierefreiheitserklärung
+
+Der in der App enthaltene Text muss bei jeder relevanten UX-/A11y-Änderung
+geprüft werden. Insbesondere sind zu aktualisieren:
+
+- Datum beziehungsweise Versionsstand der Prüfung,
+- aktueller Umsetzungsstand,
+- bekannte Barrieren,
+- Meldeweg.
+
+Neben automatisierten Widget-Tests bleibt eine manuelle Prüfung auf einem
+Android-Gerät mit TalkBack, großer Schrift, Bildschirmtastatur und
+Gestennavigation erforderlich.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ flowchart TB
 
     subgraph app["Software System: Developer-Wiki-App"]
         ui["Container\nFlutter UI\nScreens, Formulare, Navigation"]
-        services["Container\nAnwendungsservices\nGitHub-, Konfigurations-, Bild-, Prefill- und URL-Services"]
+        services["Container\nAnwendungsservices\nGitHub-, Konfigurations-, Bild-, Prefill-, App-Info- und URL-Services"]
         storage["Container\nLokaler Speicher\nGeschützte Konfiguration, PAT und temporäre Bilder"]
     end
 
@@ -66,6 +66,9 @@ flowchart TB
 - Der Pending-Zustand wird verschlüsselt lokal gespeichert, damit der externe
   Browserwechsel und ein App-Neustart den Ablauf nicht verlieren.
 - Konfigurierbare Werte wie Ziel-Repository und Workflow-Datei werden nicht unnötig im UI-Code fest verdrahtet.
+- Gemeinsame UI-Komponenten kapseln App-Menü, About, Barrierefreiheitserklärung, Fehlersammler und begrenzte Textfelder.
+- App-Bugreports werden ohne Wiki-PAT als vorbereitete URL im externen Browser geöffnet; Kontext und installierte Releaseversion werden lokal ergänzt.
+- Die installierte Releaseversion wird über eine testbare App-Info-Abstraktion aus den Android-Paketinformationen gelesen.
 - Die Architektur bleibt mobile-first, testbar und so einfach wie für den aktuellen Funktionsumfang möglich.
 
 ## Pflege

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,21 +61,21 @@ class _WikiSourceAppState extends State<WikiSourceApp> {
         future: _configuration,
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const Scaffold(
+            return Scaffold(
               appBar: AppBar(
-                title: Text('Developer Wiki'),
-                actions: [
+                title: const Text('Developer Wiki'),
+                actions: const [
                   AppSupportMenu(contextName: 'App wird geladen'),
                 ],
               ),
-              body: Center(child: CircularProgressIndicator()),
+              body: const Center(child: CircularProgressIndicator()),
             );
           }
           if (snapshot.hasError) {
             return Scaffold(
-              appBar: const AppBar(
-                title: Text('Developer Wiki'),
-                actions: [
+              appBar: AppBar(
+                title: const Text('Developer Wiki'),
+                actions: const [
                   AppSupportMenu(contextName: 'Startfehler'),
                 ],
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'screens/home_screen.dart';
 import 'screens/settings_screen.dart';
 import 'services/configuration_service.dart';
 import 'services/share_intent_service.dart';
+import 'widgets/app_support.dart';
 
 void main() => runApp(const WikiSourceApp());
 
@@ -61,11 +62,23 @@ class _WikiSourceAppState extends State<WikiSourceApp> {
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
             return const Scaffold(
+              appBar: AppBar(
+                title: Text('Developer Wiki'),
+                actions: [
+                  AppSupportMenu(contextName: 'App wird geladen'),
+                ],
+              ),
               body: Center(child: CircularProgressIndicator()),
             );
           }
           if (snapshot.hasError) {
             return Scaffold(
+              appBar: const AppBar(
+                title: Text('Developer Wiki'),
+                actions: [
+                  AppSupportMenu(contextName: 'Startfehler'),
+                ],
+              ),
               body: Center(
                 child: Padding(
                   padding: const EdgeInsets.all(24),

--- a/lib/models/app_info.dart
+++ b/lib/models/app_info.dart
@@ -1,0 +1,9 @@
+class AppInfo {
+  const AppInfo({required this.version, required this.buildNumber});
+
+  final String version;
+  final String buildNumber;
+
+  String get displayVersion =>
+      buildNumber.isEmpty ? version : '$version+$buildNumber';
+}

--- a/lib/models/source_template.dart
+++ b/lib/models/source_template.dart
@@ -9,9 +9,14 @@ class SourceField {
       this.placeholder = '',
       this.required = false,
       this.options = const [],
-      this.initialValue = ''});
+      this.initialValue = '',
+      this.maxLength});
   final String id, label, description, placeholder, initialValue;
   final FieldKind kind;
+  final int? maxLength;
+
+  int get effectiveMaxLength =>
+      maxLength ?? (kind == FieldKind.input ? 500 : 4000);
   final bool required;
   final List<String> options;
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../services/configuration_service.dart';
 import '../services/external_url_service.dart';
 import '../services/github_service.dart';
 import '../services/image_upload_service.dart';
+import '../widgets/app_support.dart';
 import 'recent_sources_screen.dart';
 import 'settings_screen.dart';
 import 'source_form_screen.dart';
@@ -143,6 +144,7 @@ class _HomeScreenState extends State<HomeScreen> {
           'Der Import-Workflow des verbundenen Wikis wird jetzt gestartet.',
         ),
         actions: [
+          const BugReportButton(contextName: 'Quellenimport-Dialog'),
           TextButton(
             onPressed: () => Navigator.pop(dialogContext, false),
             child: const Text('Abbrechen'),
@@ -287,6 +289,7 @@ class _HomeScreenState extends State<HomeScreen> {
             onPressed: _openSettings,
             icon: const Icon(Icons.settings),
           ),
+          const AppSupportMenu(contextName: 'Startseite'),
         ],
       ),
       body: ListView(

--- a/lib/screens/recent_sources_screen.dart
+++ b/lib/screens/recent_sources_screen.dart
@@ -5,6 +5,7 @@ import '../models/wiki_configuration.dart';
 import '../services/configuration_service.dart';
 import '../services/external_url_service.dart';
 import '../services/github_service.dart';
+import '../widgets/app_support.dart';
 import 'source_form_screen.dart';
 
 class RecentSourcesScreen extends StatefulWidget {
@@ -94,6 +95,7 @@ class _RecentSourcesScreenState extends State<RecentSourcesScreen> {
             onPressed: _busy ? null : _load,
             icon: const Icon(Icons.refresh),
           ),
+          const AppSupportMenu(contextName: 'Letzte Quellen'),
         ],
       ),
       body: _body(),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,6 +4,8 @@ import '../models/wiki_configuration.dart';
 import '../services/configuration_service.dart';
 import '../services/github_service.dart';
 import '../widgets/app_support.dart';
+import '../widgets/bounded_text_form_field.dart';
+import '../widgets/error_summary.dart';
 import '../widgets/pat_help_button.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -21,6 +23,14 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
+  static const _bottomClearance = 64.0;
+
+  final _formKey = GlobalKey<FormState>();
+  final _scrollController = ScrollController();
+  final _summaryFocus = FocusNode(debugLabel: 'Einstellungen-Fehlersammler');
+  final _repositoryFocus = FocusNode(debugLabel: 'GitHub Wiki');
+  final _tokenFocus = FocusNode(debugLabel: 'Fine-grained PAT');
+  final _workflowFocus = FocusNode(debugLabel: 'Import-Workflow');
   final _repositoryController = TextEditingController();
   final _tokenController = TextEditingController();
   final _workflowController = TextEditingController();
@@ -31,6 +41,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _connectionVerified = false;
   String? _status;
   bool _statusIsError = false;
+  List<String> _validationErrors = const [];
 
   @override
   void initState() {
@@ -61,51 +72,95 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
   }
 
+  List<String> _collectErrors({required bool includeWorkflow}) {
+    final errors = <String>[];
+    if (_repositoryController.text.trim().isEmpty) {
+      errors.add('GitHub Wiki: Pflichtfeld');
+    } else {
+      try {
+        GitHubRepository.parse(_repositoryController.text);
+      } on FormatException catch (error) {
+        errors.add('GitHub Wiki: ${error.message}');
+      }
+    }
+    if (_tokenController.text.trim().isEmpty) {
+      errors.add('Fine-grained PAT: Pflichtfeld');
+    }
+    if (includeWorkflow && _workflowController.text.trim().isEmpty) {
+      errors.add('Import-Workflow: Pflichtfeld');
+    }
+    return errors;
+  }
+
+  Future<bool> _showValidationErrors(List<String> errors) async {
+    if (errors.isEmpty) {
+      setState(() => _validationErrors = const []);
+      return false;
+    }
+    setState(() => _validationErrors = errors);
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(content: Text('Bitte markierte Pflichtfelder prüfen.')),
+      );
+    await _scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+    );
+    _summaryFocus.requestFocus();
+    return true;
+  }
+
+  void _focusError(String error) {
+    final label = error.split(':').first;
+    final node = switch (label) {
+      'GitHub Wiki' => _repositoryFocus,
+      'Fine-grained PAT' => _tokenFocus,
+      _ => _workflowFocus,
+    };
+    node.requestFocus();
+    final focusContext = node.context;
+    if (focusContext != null) {
+      Scrollable.ensureVisible(focusContext);
+    }
+  }
+
+  String? _required(String? value) =>
+      (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null;
+
   Future<void> _testConnection() async {
-    final token = _tokenController.text.trim();
-    if (token.isEmpty) {
-      _setStatus('Bitte zuerst ein Fine-grained PAT eingeben.', isError: true);
+    if (await _showValidationErrors(_collectErrors(includeWorkflow: false))) {
       return;
     }
-
-    GitHubRepository repository;
-    try {
-      repository = GitHubRepository.parse(_repositoryController.text);
-    } on FormatException catch (error) {
-      _setStatus(error.message.toString(), isError: true);
-      return;
-    }
-
+    final repository = GitHubRepository.parse(_repositoryController.text);
     setState(() {
       _busy = true;
       _status = 'Verbindung wird geprüft …';
       _statusIsError = false;
       _connectionVerified = false;
     });
-
     try {
       final login = await GitHubService(
-        token,
+        _tokenController.text.trim(),
         owner: repository.owner,
         repo: repository.name,
       ).verifyRepositoryAccess();
-      if (!mounted) {
-        return;
+      if (mounted) {
+        setState(() {
+          _connectionVerified = true;
+          _status = 'Verbindung erfolgreich – angemeldet als $login.';
+          _statusIsError = false;
+        });
       }
-      setState(() {
-        _connectionVerified = true;
-        _status = 'Verbindung erfolgreich – angemeldet als $login.';
-        _statusIsError = false;
-      });
     } catch (error) {
-      if (!mounted) {
-        return;
+      if (mounted) {
+        _setStatus(
+          'Zugriff fehlgeschlagen. Token, Repository und Berechtigungen prüfen: '
+          '$error',
+          isError: true,
+        );
       }
-      _setStatus(
-        'Zugriff fehlgeschlagen. Token, Repository und Berechtigungen prüfen: '
-        '$error',
-        isError: true,
-      );
     } finally {
       if (mounted) {
         setState(() => _busy = false);
@@ -114,18 +169,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _save() async {
+    if (await _showValidationErrors(_collectErrors(includeWorkflow: true))) {
+      return;
+    }
     if (!_connectionVerified) {
       _setStatus(
         'Bitte die Verbindung vor dem Speichern erfolgreich testen.',
         isError: true,
       );
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Speichern ist noch nicht möglich.')),
+      );
       return;
     }
-    if (_workflowController.text.trim().isEmpty) {
-      _setStatus('Bitte einen Import-Workflow angeben.', isError: true);
-      return;
-    }
-
     final repository = GitHubRepository.parse(_repositoryController.text);
     setState(() => _busy = true);
     try {
@@ -175,11 +231,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ..removeListener(_invalidateVerification)
       ..dispose();
     _workflowController.dispose();
+    _scrollController.dispose();
+    _summaryFocus.dispose();
+    _repositoryFocus.dispose();
+    _tokenFocus.dispose();
+    _workflowFocus.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: !widget.isSetup,
@@ -192,83 +254,109 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          TextField(
-            controller: _repositoryController,
-            enabled: !_busy,
-            keyboardType: TextInputType.url,
-            textInputAction: TextInputAction.next,
-            decoration: const InputDecoration(
-              labelText: 'GitHub Wiki',
-              helperText: 'Repository-URL oder owner/repo',
-            ),
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _tokenController,
-            enabled: !_busy,
-            obscureText: _obscure,
-            enableSuggestions: false,
-            autocorrect: false,
-            decoration: InputDecoration(
-              labelText: 'Fine-grained PAT',
-              helperText:
-                  'Das Token wird nur im geschützten lokalen Speicher abgelegt.',
-              suffixIcon: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const PatHelpButton(),
-                  IconButton(
-                    tooltip: _obscure ? 'Token anzeigen' : 'Token ausblenden',
-                    onPressed: _busy
-                        ? null
-                        : () => setState(() => _obscure = !_obscure),
-                    icon: Icon(
-                      _obscure ? Icons.visibility : Icons.visibility_off,
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          controller: _scrollController,
+          padding: const EdgeInsets.all(16),
+          children: [
+            ErrorSummary(
+              focusNode: _summaryFocus,
+              errors: _validationErrors
+                  .map(
+                    (error) => ValidationErrorItem(
+                      label: error,
+                      onActivate: () => _focusError(error),
                     ),
-                  ),
-                ],
+                  )
+                  .toList(growable: false),
+            ),
+            BoundedTextFormField(
+              controller: _repositoryController,
+              focusNode: _repositoryFocus,
+              maxLength: 300,
+              enabled: !_busy,
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.next,
+              validator: _required,
+              decoration: const InputDecoration(
+                labelText: 'GitHub Wiki',
+                helperText: 'Repository-URL oder owner/repo',
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _workflowController,
-            enabled: !_busy,
-            decoration: const InputDecoration(
-              labelText: 'Import-Workflow',
-              helperText: 'Dateiname des per workflow_dispatch startbaren Workflows',
-            ),
-          ),
-          const SizedBox(height: 20),
-          FilledButton.tonalIcon(
-            onPressed: _busy ? null : _testConnection,
-            icon: const Icon(Icons.link),
-            label: const Text('Verbindung testen'),
-          ),
-          if (_status != null) ...[
             const SizedBox(height: 16),
-            Semantics(
-              liveRegion: true,
-              child: Text(
-                _status!,
-                style: TextStyle(
-                  color: _statusIsError
-                      ? Theme.of(context).colorScheme.error
-                      : null,
+            BoundedTextFormField(
+              controller: _tokenController,
+              focusNode: _tokenFocus,
+              maxLength: 500,
+              enabled: !_busy,
+              obscureText: _obscure,
+              enableSuggestions: false,
+              autocorrect: false,
+              validator: _required,
+              decoration: InputDecoration(
+                labelText: 'Fine-grained PAT',
+                helperText:
+                    'Das Token wird nur im geschützten lokalen Speicher abgelegt.',
+                suffixIcon: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const PatHelpButton(),
+                    IconButton(
+                      tooltip: _obscure ? 'Token anzeigen' : 'Token ausblenden',
+                      onPressed: _busy
+                          ? null
+                          : () => setState(() => _obscure = !_obscure),
+                      icon: Icon(
+                        _obscure ? Icons.visibility : Icons.visibility_off,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
+            const SizedBox(height: 16),
+            BoundedTextFormField(
+              controller: _workflowController,
+              focusNode: _workflowFocus,
+              maxLength: 255,
+              enabled: !_busy,
+              validator: _required,
+              decoration: const InputDecoration(
+                labelText: 'Import-Workflow',
+                helperText:
+                    'Dateiname des per workflow_dispatch startbaren Workflows',
+              ),
+            ),
+            const SizedBox(height: 20),
+            FilledButton.tonalIcon(
+              onPressed: _busy ? null : _testConnection,
+              icon: const Icon(Icons.link),
+              label: const Text('Verbindung testen'),
+            ),
+            if (_status != null) ...[
+              const SizedBox(height: 16),
+              Semantics(
+                liveRegion: true,
+                child: Text(
+                  _status!,
+                  style: TextStyle(
+                    color: _statusIsError
+                        ? Theme.of(context).colorScheme.error
+                        : null,
+                  ),
+                ),
+              ),
+            ],
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: _busy ? null : _save,
+              icon: const Icon(Icons.save),
+              label: const Text('Speichern'),
+            ),
+            SizedBox(height: _bottomClearance + bottomInset),
           ],
-          const SizedBox(height: 20),
-          FilledButton.icon(
-            onPressed: _busy || !_connectionVerified ? null : _save,
-            icon: const Icon(Icons.save),
-            label: const Text('Speichern'),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -5,7 +5,7 @@ import '../services/configuration_service.dart';
 import '../services/github_service.dart';
 import '../widgets/app_support.dart';
 import '../widgets/bounded_text_form_field.dart';
-import '../widgets/error_summary.dart';
+import '../widgets/error_summary.dart' as validation;
 import '../widgets/pat_help_button.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -200,6 +200,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     )) {
       return;
     }
+    if (!mounted) {
+      return;
+    }
     if (!_connectionVerified) {
       _setStatus(
         'Bitte die Verbindung vor dem Speichern erfolgreich testen.',
@@ -288,11 +291,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
           controller: _scrollController,
           padding: const EdgeInsets.all(16),
           children: [
-            ErrorSummary(
+            validation.ErrorSummary(
               focusNode: _summaryFocus,
               errors: _validationErrors
                   .map(
-                    (error) => ValidationErrorItem(
+                    (error) => validation.ValidationErrorItem(
                       label: error,
                       onActivate: () => _focusError(error),
                     ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -129,6 +129,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String? _required(String? value) =>
       (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null;
 
+  String? _repositoryValidator(String? value) {
+    final requiredError = _required(value);
+    if (requiredError != null) {
+      return requiredError;
+    }
+    try {
+      GitHubRepository.parse(value!);
+      return null;
+    } on FormatException catch (error) {
+      return error.message.toString();
+    }
+  }
+
   Future<void> _testConnection() async {
     if (await _showValidationErrors(_collectErrors(includeWorkflow: false))) {
       return;
@@ -278,7 +291,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               enabled: !_busy,
               keyboardType: TextInputType.url,
               textInputAction: TextInputAction.next,
-              validator: _required,
+              validator: _repositoryValidator,
               decoration: const InputDecoration(
                 labelText: 'GitHub Wiki',
                 helperText: 'Repository-URL oder owner/repo',

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/wiki_configuration.dart';
 import '../services/configuration_service.dart';
 import '../services/github_service.dart';
+import '../widgets/app_support.dart';
 import '../widgets/pat_help_button.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -185,6 +186,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: Text(
           widget.isSetup ? 'Developer Wiki – Einrichtung' : 'Einstellungen',
         ),
+        actions: [
+          AppSupportMenu(
+            contextName: widget.isSetup ? 'Ersteinrichtung' : 'Einstellungen',
+          ),
+        ],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -93,6 +93,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<bool> _showValidationErrors(List<String> errors) async {
+    _formKey.currentState?.validate();
     if (errors.isEmpty) {
       setState(() => _validationErrors = const []);
       return false;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -41,6 +41,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _connectionVerified = false;
   String? _status;
   bool _statusIsError = false;
+  bool _validateWorkflow = false;
   List<String> _validationErrors = const [];
 
   @override
@@ -92,7 +93,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return errors;
   }
 
-  Future<bool> _showValidationErrors(List<String> errors) async {
+  Future<bool> _showValidationErrors(
+    List<String> errors, {
+    required bool includeWorkflow,
+  }) async {
+    setState(() => _validateWorkflow = includeWorkflow);
     _formKey.currentState?.validate();
     if (errors.isEmpty) {
       setState(() => _validationErrors = const []);
@@ -130,6 +135,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String? _required(String? value) =>
       (value ?? '').trim().isEmpty ? 'Pflichtfeld' : null;
 
+  String? _workflowValidator(String? value) =>
+      _validateWorkflow ? _required(value) : null;
+
   String? _repositoryValidator(String? value) {
     final requiredError = _required(value);
     if (requiredError != null) {
@@ -144,7 +152,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _testConnection() async {
-    if (await _showValidationErrors(_collectErrors(includeWorkflow: false))) {
+    if (await _showValidationErrors(
+      _collectErrors(includeWorkflow: false),
+      includeWorkflow: false,
+    )) {
       return;
     }
     final repository = GitHubRepository.parse(_repositoryController.text);
@@ -183,7 +194,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _save() async {
-    if (await _showValidationErrors(_collectErrors(includeWorkflow: true))) {
+    if (await _showValidationErrors(
+      _collectErrors(includeWorkflow: true),
+      includeWorkflow: true,
+    )) {
       return;
     }
     if (!_connectionVerified) {
@@ -335,7 +349,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               focusNode: _workflowFocus,
               maxLength: 255,
               enabled: !_busy,
-              validator: _required,
+              validator: _workflowValidator,
               decoration: const InputDecoration(
                 labelText: 'Import-Workflow',
                 helperText:

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -17,6 +17,7 @@ import '../services/image_upload_service.dart';
 import '../services/source_prefill_service.dart';
 import '../widgets/app_support.dart';
 import '../widgets/bounded_text_form_field.dart';
+import '../widgets/error_summary.dart';
 import 'settings_screen.dart';
 
 class SourceFormScreen extends StatefulWidget {
@@ -45,6 +46,10 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   static const _bottomClearance = 64.0;
 
   final key = GlobalKey<FormState>();
+  final _scrollController = ScrollController();
+  final _summaryFocus = FocusNode(debugLabel: 'Quellenformular-Fehlersammler');
+  final _titleFocus = FocusNode(debugLabel: 'Issue-Titel');
+  final _fieldFocus = <String, FocusNode>{};
   final title = TextEditingController();
   final _configurationService = ConfigurationService();
   final _externalUrlService = ExternalUrlService();
@@ -60,6 +65,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
   ImageSourceFile? _image;
   PendingImageUpload? _pendingUpload;
   String? _errorMessage;
+  List<String> _validationErrors = const [];
 
   @override
   void initState() {
@@ -95,7 +101,13 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       controller.dispose();
     }
     values.clear();
+    for (final focusNode in _fieldFocus.values) {
+      focusNode.dispose();
+    }
+    _fieldFocus.clear();
     for (final field in next.fields) {
+      _fieldFocus[field.id] = FocusNode(debugLabel: field.label);
+
       if (field.kind != FieldKind.image) {
         values[field.id] = TextEditingController(text: field.initialValue);
       }
@@ -109,12 +121,20 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     }
     _createdIssue = null;
     _errorMessage = null;
+    _validationErrors = const [];
   }
 
   Future<void> submit() async {
     final formIsValid = key.currentState?.validate() ?? false;
     if (!formIsValid || _hasMissingRequiredValues()) {
+      setState(() => _validationErrors = _collectValidationErrors());
       _showValidationHint();
+      await _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+      _summaryFocus.requestFocus();
       return;
     }
 
@@ -181,6 +201,43 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
         _image = null;
         _createdIssue = issue;
       });
+    }
+  }
+
+  List<String> _collectValidationErrors() {
+    final errors = <String>[];
+    if (title.text.trim().isEmpty) {
+      errors.add('Issue-Titel: Pflichtfeld');
+    }
+    for (final field in template.fields) {
+      final missing = field.required &&
+          (field.kind == FieldKind.image
+              ? _image == null
+              : values[field.id]!.text.trim().isEmpty);
+      if (missing) {
+        errors.add('${field.label}: Pflichtfeld');
+      }
+    }
+    return errors;
+  }
+
+  void _focusValidationError(String error) {
+    final label = error.split(':').first;
+    final node = label == 'Issue-Titel'
+        ? _titleFocus
+        : _fieldFocus.entries
+            .where((entry) =>
+                template.fields.any((field) =>
+                    field.id == entry.key && field.label == label))
+            .map((entry) => entry.value)
+            .firstOrNull;
+    if (node == null) {
+      return;
+    }
+    node.requestFocus();
+    final focusContext = node.context;
+    if (focusContext != null) {
+      Scrollable.ensureVisible(focusContext);
     }
   }
 
@@ -357,6 +414,12 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     if (image != null && _pendingUpload == null) {
       unawaited(_imageInputGateway.discard(image));
     }
+    _scrollController.dispose();
+    _summaryFocus.dispose();
+    _titleFocus.dispose();
+    for (final focusNode in _fieldFocus.values) {
+      focusNode.dispose();
+    }
     title.dispose();
     for (final controller in values.values) {
       controller.dispose();
@@ -394,8 +457,20 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       body: Form(
         key: key,
         child: ListView(
+          controller: _scrollController,
           padding: const EdgeInsets.all(16),
           children: [
+            ErrorSummary(
+              focusNode: _summaryFocus,
+              errors: _validationErrors
+                  .map(
+                    (error) => ValidationErrorItem(
+                      label: error,
+                      onActivate: () => _focusValidationError(error),
+                    ),
+                  )
+                  .toList(growable: false),
+            ),
             if (sharedContent != null) ...[
               const Text(
                 'Geteilter Inhalt wurde vorausgefüllt und kann bearbeitet werden.',
@@ -430,8 +505,10 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             if (_errorMessage != null) _errorCard(_errorMessage!),
             ValueListenableBuilder<TextEditingValue>(
               valueListenable: title,
-              builder: (context, value, _) => TextFormField(
+              builder: (context, value, _) => BoundedTextFormField(
                 controller: title,
+                focusNode: _titleFocus,
+                maxLength: 256,
                 enabled: !busy && _pendingUpload == null,
                 decoration: InputDecoration(
                   labelText: 'Issue-Titel',
@@ -545,6 +622,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
         child: ValueListenableBuilder<TextEditingValue>(
           valueListenable: controller,
           builder: (context, value, _) => DropdownButtonFormField<String>(
+            focusNode: _fieldFocus[field.id],
             key: ValueKey('${field.id}:${value.text}'),
             initialValue: value.text.isEmpty ? null : value.text,
             decoration: InputDecoration(
@@ -576,8 +654,10 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
       padding: const EdgeInsets.only(bottom: 12),
       child: ValueListenableBuilder<TextEditingValue>(
         valueListenable: controller,
-        builder: (context, value, _) => TextFormField(
+        builder: (context, value, _) => BoundedTextFormField(
           controller: controller,
+          focusNode: _fieldFocus[field.id],
+          maxLength: field.effectiveMaxLength,
           enabled: !busy && _pendingUpload == null,
           minLines: field.kind == FieldKind.textarea ? 3 : 1,
           maxLines: field.kind == FieldKind.textarea ? 8 : 1,
@@ -603,7 +683,9 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
     final image = _image;
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
-      child: FormField<ImageSourceFile>(
+      child: Focus(
+        focusNode: _fieldFocus[field.id],
+        child: FormField<ImageSourceFile>(
         key: const Key('image-source-field'),
         initialValue: image,
         validator: (_) =>
@@ -737,6 +819,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               ],
             ),
           ],
+        ),
         ),
       ),
     );

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -223,14 +223,17 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
 
   void _focusValidationError(String error) {
     final label = error.split(':').first;
-    final node = label == 'Issue-Titel'
-        ? _titleFocus
-        : _fieldFocus.entries
-            .where((entry) =>
-                template.fields.any((field) =>
-                    field.id == entry.key && field.label == label))
-            .map((entry) => entry.value)
-            .firstOrNull;
+    FocusNode? node;
+    if (label == 'Issue-Titel') {
+      node = _titleFocus;
+    } else {
+      for (final field in template.fields) {
+        if (field.label == label) {
+          node = _fieldFocus[field.id];
+          break;
+        }
+      }
+    }
     if (node == null) {
       return;
     }
@@ -779,6 +782,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             ],
           ],
         ),
+        ),
       ),
     );
   }
@@ -819,7 +823,6 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               ],
             ),
           ],
-        ),
         ),
       ),
     );

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -17,7 +17,7 @@ import '../services/image_upload_service.dart';
 import '../services/source_prefill_service.dart';
 import '../widgets/app_support.dart';
 import '../widgets/bounded_text_form_field.dart';
-import '../widgets/error_summary.dart';
+import '../widgets/error_summary.dart' as validation;
 import 'settings_screen.dart';
 
 class SourceFormScreen extends StatefulWidget {
@@ -463,11 +463,11 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
           controller: _scrollController,
           padding: const EdgeInsets.all(16),
           children: [
-            ErrorSummary(
+            validation.ErrorSummary(
               focusNode: _summaryFocus,
               errors: _validationErrors
                   .map(
-                    (error) => ValidationErrorItem(
+                    (error) => validation.ValidationErrorItem(
                       label: error,
                       onActivate: () => _focusValidationError(error),
                     ),

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -15,6 +15,8 @@ import '../services/github_service.dart';
 import '../services/image_input_service.dart';
 import '../services/image_upload_service.dart';
 import '../services/source_prefill_service.dart';
+import '../widgets/app_support.dart';
+import '../widgets/bounded_text_form_field.dart';
 import 'settings_screen.dart';
 
 class SourceFormScreen extends StatefulWidget {
@@ -381,6 +383,11 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
               MaterialPageRoute(builder: (_) => const SettingsScreen()),
             ),
             icon: const Icon(Icons.settings),
+          ),
+          AppSupportMenu(
+            contextName: sharedContent == null
+                ? 'Quellenformular'
+                : 'Geteilten Inhalt erfassen',
           ),
         ],
       ),

--- a/lib/services/app_info_service.dart
+++ b/lib/services/app_info_service.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/services.dart';
+
+import '../models/app_info.dart';
+
+abstract interface class AppInfoGateway {
+  Future<AppInfo> load();
+}
+
+class AppInfoService implements AppInfoGateway {
+  static const _channel = MethodChannel('developer_wiki/app_info');
+
+  @override
+  Future<AppInfo> load() async {
+    final data = await _channel.invokeMapMethod<String, dynamic>('getAppInfo');
+    final version = data?['version']?.toString().trim() ?? '';
+    final buildNumber = data?['buildNumber']?.toString().trim() ?? '';
+    if (version.isEmpty) {
+      throw const FormatException('Die installierte App-Version fehlt.');
+    }
+    return AppInfo(version: version, buildNumber: buildNumber);
+  }
+}

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -380,6 +380,7 @@ class _BugReportDialogState extends State<_BugReportDialog> {
                 DropdownButtonFormField<String>(
                   focusNode: _typeFocus,
                   initialValue: _type,
+                  hint: const Text('Bitte auswählen'),
                   decoration: const InputDecoration(
                     labelText: 'Fehlerart *',
                     helperText: 'Bitte eine Fehlerart auswählen.',

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -1,0 +1,457 @@
+import 'package:flutter/material.dart';
+
+import '../models/app_info.dart';
+import '../services/app_info_service.dart';
+import '../services/external_url_service.dart';
+import 'bounded_text_form_field.dart';
+import 'error_summary.dart';
+
+const _appRepository = 'Huluvu424242/developer-wiki-app';
+
+class AppSupportMenu extends StatelessWidget {
+  const AppSupportMenu({
+    super.key,
+    required this.contextName,
+    this.appInfoGateway,
+    this.externalUrlService,
+  });
+
+  final String contextName;
+  final AppInfoGateway? appInfoGateway;
+  final ExternalUrlService? externalUrlService;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<_SupportAction>(
+      tooltip: 'App-Menü öffnen',
+      onSelected: (action) {
+        switch (action) {
+          case _SupportAction.reportBug:
+            showBugReport(
+              context,
+              contextName: contextName,
+              appInfoGateway: appInfoGateway,
+              externalUrlService: externalUrlService,
+            );
+          case _SupportAction.about:
+            showAppAbout(
+              context,
+              contextName: contextName,
+              appInfoGateway: appInfoGateway,
+              externalUrlService: externalUrlService,
+            );
+        }
+      },
+      itemBuilder: (_) => const [
+        PopupMenuItem(
+          value: _SupportAction.reportBug,
+          child: Text('Bug melden'),
+        ),
+        PopupMenuItem(
+          value: _SupportAction.about,
+          child: Text('Über'),
+        ),
+      ],
+    );
+  }
+}
+
+enum _SupportAction { reportBug, about }
+
+class BugReportButton extends StatelessWidget {
+  const BugReportButton({
+    super.key,
+    required this.contextName,
+    this.appInfoGateway,
+    this.externalUrlService,
+  });
+
+  final String contextName;
+  final AppInfoGateway? appInfoGateway;
+  final ExternalUrlService? externalUrlService;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: () => showBugReport(
+        context,
+        contextName: contextName,
+        appInfoGateway: appInfoGateway,
+        externalUrlService: externalUrlService,
+      ),
+      icon: const Icon(Icons.bug_report_outlined),
+      label: const Text('Bug melden'),
+    );
+  }
+}
+
+Future<void> showAppAbout(
+  BuildContext context, {
+  required String contextName,
+  AppInfoGateway? appInfoGateway,
+  ExternalUrlService? externalUrlService,
+}) async {
+  final gateway = appInfoGateway ?? AppInfoService();
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: const Text('Über Developer Wiki'),
+      content: FutureBuilder<AppInfo>(
+        future: gateway.load(),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Semantics(
+              liveRegion: true,
+              child: Text(
+                'Releaseversion konnte nicht geladen werden: ${snapshot.error}',
+              ),
+            );
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('Developer-Wiki-App'),
+              const SizedBox(height: 8),
+              Text('Releaseversion ${snapshot.data!.displayVersion}'),
+            ],
+          );
+        },
+      ),
+      actions: [
+        BugReportButton(
+          contextName: 'About-Dialog',
+          appInfoGateway: gateway,
+          externalUrlService: externalUrlService,
+        ),
+        TextButton(
+          onPressed: () => showAccessibilityStatement(
+            dialogContext,
+            appInfoGateway: gateway,
+            externalUrlService: externalUrlService,
+          ),
+          child: const Text('Barrierefreiheitserklärung'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(dialogContext),
+          child: const Text('Schließen'),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<void> showAccessibilityStatement(
+  BuildContext context, {
+  AppInfoGateway? appInfoGateway,
+  ExternalUrlService? externalUrlService,
+}) =>
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Barrierefreiheitserklärung'),
+        content: const SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Stand: 26. August 2026',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 12),
+              Text(
+                'Die Developer-Wiki-App wird nach den im Projekt festgelegten '
+                'UX- und Barrierefreiheitsregeln weiterentwickelt. Formulare '
+                'bieten verständliche Beschriftungen, feldnahe Fehler, einen '
+                'Fehlersammler und Unterstützung für vergrößerte Schrift.',
+              ),
+              SizedBox(height: 12),
+              Text(
+                'Bekannte Barrieren',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 4),
+              Text(
+                'Die praktische Prüfung mit unterschiedlichen Android-'
+                'Screenreadern und Schaltersteuerungen ist noch nicht für '
+                'jede Gerätekombination abgeschlossen. Externe GitHub-Seiten '
+                'liegen außerhalb des Einflussbereichs dieser App.',
+              ),
+              SizedBox(height: 12),
+              Text(
+                'Barrieren melden',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 4),
+              Text(
+                'Über „Bug melden“ kann eine Barriere mit App-Version und '
+                'aktuellem Nutzungskontext gemeldet werden.',
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          BugReportButton(
+            contextName: 'Barrierefreiheitserklärung',
+            appInfoGateway: appInfoGateway,
+            externalUrlService: externalUrlService,
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Schließen'),
+          ),
+        ],
+      ),
+    );
+
+Future<void> showBugReport(
+  BuildContext context, {
+  required String contextName,
+  AppInfoGateway? appInfoGateway,
+  ExternalUrlService? externalUrlService,
+}) async {
+  final gateway = appInfoGateway ?? AppInfoService();
+  AppInfo appInfo;
+  try {
+    appInfo = await gateway.load();
+  } catch (error) {
+    if (!context.mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Releaseversion konnte nicht geladen werden: $error')),
+    );
+    return;
+  }
+  if (!context.mounted) {
+    return;
+  }
+  await showDialog<void>(
+    context: context,
+    builder: (_) => _BugReportDialog(
+      contextName: contextName,
+      appInfo: appInfo,
+      externalUrlService: externalUrlService ?? ExternalUrlService(),
+    ),
+  );
+}
+
+class _BugReportDialog extends StatefulWidget {
+  const _BugReportDialog({
+    required this.contextName,
+    required this.appInfo,
+    required this.externalUrlService,
+  });
+
+  final String contextName;
+  final AppInfo appInfo;
+  final ExternalUrlService externalUrlService;
+
+  @override
+  State<_BugReportDialog> createState() => _BugReportDialogState();
+}
+
+class _BugReportDialogState extends State<_BugReportDialog> {
+  static const _descriptionMaxLength = 2000;
+
+  final _formKey = GlobalKey<FormState>();
+  final _scrollController = ScrollController();
+  final _summaryFocus = FocusNode(debugLabel: 'Bugreport-Fehlersammler');
+  final _typeFocus = FocusNode(debugLabel: 'Fehlerart');
+  final _descriptionFocus = FocusNode(debugLabel: 'Fehlerbeschreibung');
+  final _description = TextEditingController();
+  String? _type;
+  bool _showErrors = false;
+  bool _busy = false;
+  String? _errorMessage;
+
+  List<ValidationErrorItem> get _errors {
+    if (!_showErrors || _type != null) {
+      return const [];
+    }
+    return [
+      ValidationErrorItem(
+        label: 'Fehlerart: Bitte auswählen',
+        onActivate: () => _focus(_typeFocus),
+      ),
+    ];
+  }
+
+  void _focus(FocusNode node) {
+    node.requestFocus();
+    final focusContext = node.context;
+    if (focusContext != null) {
+      Scrollable.ensureVisible(focusContext);
+    }
+  }
+
+  Future<void> _submit() async {
+    final valid = _formKey.currentState?.validate() ?? false;
+    if (!valid) {
+      setState(() => _showErrors = true);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bitte markierte Pflichtfelder prüfen.')),
+      );
+      await _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+      _summaryFocus.requestFocus();
+      return;
+    }
+
+    setState(() {
+      _busy = true;
+      _errorMessage = null;
+    });
+    final title = '[${_type!}] App-Fehler in ${widget.contextName}';
+    final body = [
+      '## Fehlerart',
+      _type!,
+      '',
+      '## Kontext',
+      widget.contextName,
+      '',
+      '## Releaseversion',
+      widget.appInfo.displayVersion,
+      '',
+      '## Beschreibung',
+      _description.text.trim().isEmpty
+          ? 'Keine zusätzliche Beschreibung angegeben.'
+          : _description.text.trim(),
+    ].join('\n');
+    final uri = Uri.https(
+      'github.com',
+      '/$_appRepository/issues/new',
+      {
+        'labels': 'bug',
+        'title': title,
+        'body': body,
+      },
+    );
+    try {
+      await widget.externalUrlService.open(uri.toString());
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _errorMessage = 'Bugreport konnte nicht auf GitHub geöffnet werden: $error';
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    _summaryFocus.dispose();
+    _typeFocus.dispose();
+    _descriptionFocus.dispose();
+    _description.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Bug melden'),
+      content: SizedBox(
+        width: 520,
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ErrorSummary(errors: _errors, focusNode: _summaryFocus),
+                Text('Kontext: ${widget.contextName}'),
+                Text('Releaseversion: ${widget.appInfo.displayVersion}'),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<String>(
+                  focusNode: _typeFocus,
+                  initialValue: _type,
+                  decoration: const InputDecoration(
+                    labelText: 'Fehlerart *',
+                    helperText: 'Bitte eine Fehlerart auswählen.',
+                  ),
+                  items: const [
+                    DropdownMenuItem(
+                      value: 'Barrierefreiheitsfehler',
+                      child: Text('Barrierefreiheitsfehler'),
+                    ),
+                    DropdownMenuItem(
+                      value: 'Darstellungsfehler',
+                      child: Text('Darstellungsfehler'),
+                    ),
+                    DropdownMenuItem(
+                      value: 'Funktionsfehler',
+                      child: Text('Funktionsfehler'),
+                    ),
+                    DropdownMenuItem(
+                      value: 'Sonstiges',
+                      child: Text('Sonstiges'),
+                    ),
+                  ],
+                  onChanged: _busy
+                      ? null
+                      : (value) => setState(() => _type = value),
+                  validator: (value) =>
+                      value == null ? 'Bitte eine Fehlerart auswählen.' : null,
+                ),
+                const SizedBox(height: 16),
+                BoundedTextFormField(
+                  controller: _description,
+                  focusNode: _descriptionFocus,
+                  maxLength: _descriptionMaxLength,
+                  minLines: 4,
+                  maxLines: 8,
+                  enabled: !_busy,
+                  decoration: const InputDecoration(
+                    labelText: 'Beschreibung',
+                    helperText:
+                        'Keine Zugangsdaten oder persönlichen Daten eintragen.',
+                    alignLabelWithHint: true,
+                  ),
+                ),
+                if (_errorMessage != null) ...[
+                  const SizedBox(height: 12),
+                  Semantics(
+                    liveRegion: true,
+                    child: Text(
+                      _errorMessage!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 64),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _busy ? null : () => Navigator.pop(context),
+          child: const Text('Abbrechen'),
+        ),
+        FilledButton.icon(
+          onPressed: _busy ? null : _submit,
+          icon: const Icon(Icons.open_in_new),
+          label: Text(_busy ? 'Wird geöffnet …' : 'Auf GitHub prüfen'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -4,7 +4,7 @@ import '../models/app_info.dart';
 import '../services/app_info_service.dart';
 import '../services/external_url_service.dart';
 import 'bounded_text_form_field.dart';
-import 'error_summary.dart';
+import 'error_summary.dart' as validation;
 
 const _appRepository = 'Huluvu424242/developer-wiki-app';
 
@@ -269,12 +269,12 @@ class _BugReportDialogState extends State<_BugReportDialog> {
   bool _busy = false;
   String? _errorMessage;
 
-  List<ValidationErrorItem> get _errors {
+  List<validation.ValidationErrorItem> get _errors {
     if (!_showErrors || _type != null) {
       return const [];
     }
     return [
-      ValidationErrorItem(
+      validation.ValidationErrorItem(
         label: 'Fehlerart: Bitte auswählen',
         onActivate: () => _focus(_typeFocus),
       ),
@@ -374,7 +374,7 @@ class _BugReportDialogState extends State<_BugReportDialog> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                ErrorSummary(errors: _errors, focusNode: _summaryFocus),
+                validation.ErrorSummary(errors: _errors, focusNode: _summaryFocus),
                 Text('Kontext: ${widget.contextName}'),
                 Text('Releaseversion: ${widget.appInfo.displayVersion}'),
                 const SizedBox(height: 16),

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -329,6 +329,7 @@ class _BugReportDialogState extends State<_BugReportDialog> {
       'github.com',
       '/$_appRepository/issues/new',
       {
+        'template': 'app_bug_report.md',
         'labels': 'bug',
         'title': title,
         'body': body,

--- a/lib/widgets/bounded_text_form_field.dart
+++ b/lib/widgets/bounded_text_form_field.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/semantics.dart';
+
+class BoundedTextFormField extends StatefulWidget {
+  const BoundedTextFormField({
+    super.key,
+    required this.controller,
+    required this.maxLength,
+    required this.decoration,
+    this.focusNode,
+    this.validator,
+    this.enabled = true,
+    this.keyboardType,
+    this.textInputAction,
+    this.obscureText = false,
+    this.enableSuggestions = true,
+    this.autocorrect = true,
+    this.minLines,
+    this.maxLines = 1,
+  });
+
+  final TextEditingController controller;
+  final int maxLength;
+  final InputDecoration decoration;
+  final FocusNode? focusNode;
+  final FormFieldValidator<String>? validator;
+  final bool enabled;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final bool obscureText;
+  final bool enableSuggestions;
+  final bool autocorrect;
+  final int? minLines;
+  final int? maxLines;
+
+  @override
+  State<BoundedTextFormField> createState() => _BoundedTextFormFieldState();
+}
+
+class _BoundedTextFormFieldState extends State<BoundedTextFormField> {
+  bool _limitAnnounced = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_handleLength);
+  }
+
+  @override
+  void didUpdateWidget(covariant BoundedTextFormField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_handleLength);
+      widget.controller.addListener(_handleLength);
+      _limitAnnounced = false;
+    }
+  }
+
+  void _handleLength() {
+    final atLimit = widget.controller.text.characters.length >= widget.maxLength;
+    if (atLimit && !_limitAnnounced) {
+      _limitAnnounced = true;
+      SystemSound.play(SystemSoundType.alert);
+      SemanticsService.announce(
+        'Kein Zeichen mehr möglich',
+        Directionality.of(context),
+      );
+    } else if (!atLimit) {
+      _limitAnnounced = false;
+    }
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_handleLength);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      enabled: widget.enabled,
+      keyboardType: widget.keyboardType,
+      textInputAction: widget.textInputAction,
+      obscureText: widget.obscureText,
+      enableSuggestions: widget.enableSuggestions,
+      autocorrect: widget.autocorrect,
+      minLines: widget.obscureText ? 1 : widget.minLines,
+      maxLines: widget.obscureText ? 1 : widget.maxLines,
+      maxLength: widget.maxLength,
+      maxLengthEnforcement: MaxLengthEnforcement.enforced,
+      decoration: widget.decoration,
+      validator: widget.validator,
+      buildCounter: (
+        context, {
+        required currentLength,
+        required isFocused,
+        required maxLength,
+      }) {
+        final remaining = (maxLength ?? widget.maxLength) - currentLength;
+        if (remaining > 10) {
+          return null;
+        }
+        final message =
+            remaining == 0 ? 'Kein Zeichen mehr möglich' : 'noch $remaining Zeichen';
+        return Semantics(
+          liveRegion: remaining == 0,
+          label: message,
+          child: Text(message),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/bounded_text_form_field.dart
+++ b/lib/widgets/bounded_text_form_field.dart
@@ -101,7 +101,7 @@ class _BoundedTextFormFieldState extends State<BoundedTextFormField> {
         context, {
         required currentLength,
         required isFocused,
-        required maxLength,
+        maxLength,
       }) {
         final remaining = (maxLength ?? widget.maxLength) - currentLength;
         if (remaining > 10) {

--- a/lib/widgets/bounded_text_form_field.dart
+++ b/lib/widgets/bounded_text_form_field.dart
@@ -62,7 +62,8 @@ class _BoundedTextFormFieldState extends State<BoundedTextFormField> {
     if (atLimit && !_limitAnnounced) {
       _limitAnnounced = true;
       SystemSound.play(SystemSoundType.alert);
-      SemanticsService.announce(
+      SemanticsService.sendAnnouncement(
+        View.of(context),
         'Kein Zeichen mehr möglich',
         Directionality.of(context),
       );

--- a/lib/widgets/error_summary.dart
+++ b/lib/widgets/error_summary.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class ValidationErrorItem {
+  const ValidationErrorItem({
+    required this.label,
+    required this.onActivate,
+  });
+
+  final String label;
+  final VoidCallback onActivate;
+}
+
+class ErrorSummary extends StatelessWidget {
+  const ErrorSummary({
+    super.key,
+    required this.errors,
+    this.focusNode,
+  });
+
+  final List<ValidationErrorItem> errors;
+  final FocusNode? focusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    if (errors.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final colors = Theme.of(context).colorScheme;
+    return Focus(
+      focusNode: focusNode,
+      child: Semantics(
+        container: true,
+        liveRegion: true,
+        label: '${errors.length} Fehler in den Eingaben',
+        child: Card(
+          key: const Key('validation-error-summary'),
+          color: colors.errorContainer,
+          margin: const EdgeInsets.only(bottom: 16),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Fehler in den Eingaben',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                ...errors.map(
+                  (error) => TextButton.icon(
+                    onPressed: error.onActivate,
+                    icon: const Icon(Icons.arrow_forward),
+                    label: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(error.label),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/pat_help_button.dart
+++ b/lib/widgets/pat_help_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'app_support.dart';
+
 class PatHelpButton extends StatelessWidget {
   const PatHelpButton({super.key});
 
@@ -86,6 +88,7 @@ class _PatHelpDialog extends StatelessWidget {
         ),
       ),
       actions: [
+        const BugReportButton(contextName: 'PAT-Hilfedialog'),
         TextButton(
           onPressed: Navigator.of(context).pop,
           child: const Text('Schließen'),

--- a/test/app_support_test.dart
+++ b/test/app_support_test.dart
@@ -71,7 +71,12 @@ void main() {
     await tester.pump();
     expect(find.byKey(const Key('validation-error-summary')), findsOneWidget);
 
-    await tester.tap(find.text('Bitte auswählen').last);
+    final typeDropdown = find.byType(DropdownButtonFormField<String>);
+    await tester.ensureVisible(typeDropdown);
+    await tester.pumpAndSettle();
+    final tappableTypeDropdown = typeDropdown.hitTestable();
+    expect(tappableTypeDropdown, findsOneWidget);
+    await tester.tap(tappableTypeDropdown);
     await tester.pumpAndSettle();
     await tester.tap(find.text('Barrierefreiheitsfehler').last);
     await tester.enterText(

--- a/test/app_support_test.dart
+++ b/test/app_support_test.dart
@@ -1,0 +1,135 @@
+import 'package:developer_wiki_source_capture/models/app_info.dart';
+import 'package:developer_wiki_source_capture/services/app_info_service.dart';
+import 'package:developer_wiki_source_capture/services/external_url_service.dart';
+import 'package:developer_wiki_source_capture/widgets/app_support.dart';
+import 'package:developer_wiki_source_capture/widgets/bounded_text_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('About shows installed release and accessibility statement', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              AppSupportMenu(
+                contextName: 'Testseite',
+                appInfoGateway: const _FakeAppInfoGateway(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('App-Menü öffnen'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Über'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Releaseversion 1.2.3+45'), findsOneWidget);
+    expect(find.text('Barrierefreiheitserklärung'), findsOneWidget);
+
+    await tester.tap(find.text('Barrierefreiheitserklärung'));
+    await tester.pumpAndSettle();
+    expect(find.text('Bekannte Barrieren'), findsOneWidget);
+    expect(find.text('Bug melden'), findsWidgets);
+  });
+
+  testWidgets('bug report requires type and opens prefilled app issue', (
+    tester,
+  ) async {
+    final urlService = _FakeExternalUrlService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              AppSupportMenu(
+                contextName: 'Quellenformular',
+                appInfoGateway: const _FakeAppInfoGateway(),
+                externalUrlService: urlService,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('App-Menü öffnen'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Bug melden'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Kontext: Quellenformular'), findsOneWidget);
+    expect(find.text('Releaseversion: 1.2.3+45'), findsOneWidget);
+
+    await tester.tap(find.text('Auf GitHub prüfen'));
+    await tester.pump();
+    expect(find.byKey(const Key('validation-error-summary')), findsOneWidget);
+
+    await tester.tap(find.text('Bitte auswählen').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Barrierefreiheitsfehler').last);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Beschreibung'),
+      'Der Fokus ist nicht sichtbar.',
+    );
+    await tester.tap(find.text('Auf GitHub prüfen'));
+    await tester.pumpAndSettle();
+
+    final uri = Uri.parse(urlService.openedUrl!);
+    expect(uri.host, 'github.com');
+    expect(uri.path, '/Huluvu424242/developer-wiki-app/issues/new');
+    expect(uri.queryParameters['labels'], 'bug');
+    expect(uri.queryParameters['body'], contains('Quellenformular'));
+    expect(uri.queryParameters['body'], contains('1.2.3+45'));
+    expect(uri.queryParameters['body'], isNot(contains('token')));
+  });
+
+  testWidgets('remaining-character counter starts at ten characters', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BoundedTextFormField(
+            controller: controller,
+            maxLength: 20,
+            decoration: const InputDecoration(labelText: 'Text'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField), '1234567890');
+    await tester.pump();
+    expect(find.text('noch 10 Zeichen'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField), '12345678901234567890');
+    await tester.pump();
+    expect(find.text('Kein Zeichen mehr möglich'), findsOneWidget);
+  });
+}
+
+class _FakeAppInfoGateway implements AppInfoGateway {
+  const _FakeAppInfoGateway();
+
+  @override
+  Future<AppInfo> load() async =>
+      const AppInfo(version: '1.2.3', buildNumber: '45');
+}
+
+class _FakeExternalUrlService extends ExternalUrlService {
+  String? openedUrl;
+
+  @override
+  Future<void> open(String url) async {
+    openedUrl = url;
+  }
+}

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -74,12 +74,24 @@ void main() {
     expect(errorSummary, findsOneWidget);
     expect(find.text('Issue-Titel: Pflichtfeld'), findsOneWidget);
 
-    await tester.tap(find.text('Issue-Titel: Pflichtfeld'));
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'Issue-Titel',
+    final titleErrorLink = find.ancestor(
+      of: find.text('Issue-Titel: Pflichtfeld'),
+      matching: find.byType(TextButton),
     );
+    await tester.ensureVisible(titleErrorLink);
+    await tester.pumpAndSettle();
+    final tappableTitleErrorLink = titleErrorLink.hitTestable();
+    expect(tappableTitleErrorLink, findsOneWidget);
+    await tester.tap(tappableTitleErrorLink);
+    await tester.pump();
+
+    final titleEditable = tester.widget<EditableText>(
+      find.descendant(
+        of: find.widgetWithText(TextFormField, 'Issue-Titel'),
+        matching: find.byType(EditableText),
+      ),
+    );
+    expect(titleEditable.focusNode.hasFocus, isTrue);
   });
 
   testWidgets('clears a default value with one tap', (tester) async {

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -74,10 +74,10 @@ void main() {
 
     await tester.tap(find.text('Issue-Titel: Pflichtfeld'));
     await tester.pump();
-    final titleField = tester.widget<TextFormField>(
-      find.widgetWithText(TextFormField, 'Issue-Titel'),
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'Issue-Titel',
     );
-    expect(titleField.focusNode?.hasFocus, isTrue);
   });
 
   testWidgets('clears a default value with one tap', (tester) async {

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -59,17 +59,19 @@ void main() {
       scrollable: find.byType(Scrollable).first,
     );
     await tester.ensureVisible(saveButton);
-    await tester.pump();
-    await tester.tap(saveButton);
+    await tester.pumpAndSettle();
+    final tappableSaveButton = saveButton.hitTestable();
+    expect(tappableSaveButton, findsOneWidget);
+    await tester.tap(tappableSaveButton);
+
+    final errorSummary = find.byKey(
+      const Key('validation-error-summary'),
+    );
+    await pumpUntilFound(tester, errorSummary);
 
     final validationHint = find.text('Bitte markierte Pflichtfelder prüfen.');
-    await pumpUntilFound(tester, validationHint);
-
     expect(validationHint, findsOneWidget);
-    expect(
-      find.byKey(const Key('validation-error-summary')),
-      findsOneWidget,
-    );
+    expect(errorSummary, findsOneWidget);
     expect(find.text('Issue-Titel: Pflichtfeld'), findsOneWidget);
 
     await tester.tap(find.text('Issue-Titel: Pflichtfeld'));

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -66,6 +66,18 @@ void main() {
     await pumpUntilFound(tester, validationHint);
 
     expect(validationHint, findsOneWidget);
+    expect(
+      find.byKey(const Key('validation-error-summary')),
+      findsOneWidget,
+    );
+    expect(find.text('Issue-Titel: Pflichtfeld'), findsOneWidget);
+
+    await tester.tap(find.text('Issue-Titel: Pflichtfeld'));
+    await tester.pump();
+    final titleField = tester.widget<TextFormField>(
+      find.widgetWithText(TextFormField, 'Issue-Titel'),
+    );
+    expect(titleField.focusNode?.hasFocus, isTrue);
   });
 
   testWidgets('clears a default value with one tap', (tester) async {


### PR DESCRIPTION
## Zusammenfassung

Setzt die appweite UX- und Barrierefreiheitsbasis aus Story #121 um:

- gemeinsames App-Menü mit `Bug melden` und `Über` auf allen Screens,
- About-Dialog mit tatsächlich installierter Release- und Buildnummer,
- offline verfügbare Barrierefreiheitserklärung,
- PAT-freier, kontextbezogener GitHub-Bugreport mit Pflichtauswahl und 2000-Zeichen-Freitext,
- repositoryseitiges Bugreport-Template mit festem Label `bug`,
- Fehlersammler mit Feldnavigation und Fokussteuerung,
- feldnahe Validierung in Quellenformular und Einstellungen,
- zentrale fachliche Feldlängen und barrierefreie Restzeichenzähler,
- sichtbare, semantische und akustische Rückmeldung an Zeichengrenzen,
- reservierter Platz unter Aktionsbereichen,
- Widget-Tests und aktualisierte Projekt-/Architekturdokumentation.

Der Bugreport verwendet niemals das Wiki-PAT. Er öffnet eine vorbereitete HTTPS-URL für `Huluvu424242/developer-wiki-app` und das repositoryseitige Template `app_bug_report.md` im Browser. Der Nutzer kann die Meldung vor dem Absenden prüfen.

Closes #121
Fixes #125

## Architektur

- `AppInfoGateway` kapselt die Android-Paketinformationen testbar.
- `AppSupportMenu` bündelt About, Erklärung und Bugreport.
- `BoundedTextFormField` bündelt Zeichenlimit, Restzeichenzähler, Screenreader-Ansage und Tonsignal.
- `ErrorSummary` bündelt die zusätzlichen verlinkten Formularfehler.
- Der vorhandene `ExternalUrlService` bleibt der einzige Weg zum externen Browser.

## Prüfungen

- Akzeptanzkriterien von #121 gegen die Implementierung geprüft
- bestehende Validierungshinweise, Inline-Fehler und unterer Abstand beibehalten
- Widget-Tests für About, Erklärung, Bugreport, Fehlersammler, Feldfokus und Zeichenzähler ergänzt
- die acht gemeldeten Analyzer-Befunde aus #125 durch Import-Aliase, `mounted`-Schutz und einen Focus-Manager-Test behoben
- geänderte Dart-/Kotlin-Dateien auf ausgeglichene Struktur und Konfliktmarker geprüft
- keine Secrets, Telemetrie oder zusätzlichen PAT-Berechtigungen eingeführt

Im Repository existiert kein automatisch bei Pull Requests laufender Flutter-CI-Workflow. Die aktuelle Arbeitsumgebung enthält außerdem weder Flutter noch Dart. `dart format`, `flutter analyze` und `flutter test` müssen deshalb im menschlichen Review lokal ausgeführt werden; der PR stellt sie nicht fälschlich als bereits erfolgreich dar.

## Dokumentation

Aktualisiert:

- `CHANGELOG.md`
- `README.md`
- `docs/README.md`
- `docs/architecture.md`
- neu: `docs/accessibility.md`

`ATTRIBUTIONS.md` bleibt unverändert, da keine neue Laufzeitabhängigkeit aufgenommen wurde.

## Lokale Prüfung

1. `dart format` auf den geänderten Dart-Dateien ausführen und daraus entstehende Formatänderungen committen.
2. `flutter analyze` ausführen.
3. `flutter test` ausführen.
4. TalkBack-Fokus beim Fehlersammler und bei Feldlinks prüfen.
5. Große Schrift und Bildschirmtastatur in Formularen/Dialogen prüfen.
6. Akustische Grenzrückmeldung auf einem Android-Gerät prüfen.
7. Vorbereiteten GitHub-Bugreport einschließlich Label `bug` vor dem Absenden prüfen.