### PR TITLE
feat: Protection Rules auf Release-Branches erweitern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Changed
 
+- Das importierbare Branch-Ruleset schützt neben `master` jetzt auch alle Branches unter `release/**`.
 - Einstellungen verwenden jetzt feldnahe Validierung, temporäre Hinweise und reservierten Platz unter den Aktionsschaltflächen.
 
 ## [0.1.0+3] - 2026-08-25

--- a/gh-rulesets/master-protection.json
+++ b/gh-rulesets/master-protection.json
@@ -1,11 +1,12 @@
 {
-  "name": "Protect master",
+  "name": "Protect master and release branches",
   "target": "branch",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
       "include": [
-        "refs/heads/master"
+        "refs/heads/master",
+        "refs/heads/release/**"
       ],
       "exclude": []
     }


### PR DESCRIPTION
## Zusammenfassung

Das importierbare Branch-Ruleset schützt künftig neben `master` auch alle Branches unter `release/**`.

Konkret wurde `refs/heads/release/**` zur Include-Liste des Rulesets ergänzt. Die vorhandenen Regeln bleiben unverändert:

- Änderungen ausschließlich über Pull Requests,
- Review-Threads müssen aufgelöst sein,
- Löschschutz,
- Schutz vor Non-Fast-Forward-Updates.

Closes #126

## Prüfungen

- Ruleset als JSON erfolgreich geparst
- Include-Liste enthält weiterhin `refs/heads/master`
- Include-Liste enthält zusätzlich `refs/heads/release/**`
- Include-Liste enthält keine weiteren Branch-Muster
- bestehende Regeln und Parameter unverändert übernommen
- keine Secrets oder zusätzlichen Berechtigungen eingeführt

## Dokumentation

- `CHANGELOG.md` unter `Unreleased / Changed` aktualisiert
- Keine Änderung an README oder weiterer Dokumentation erforderlich, da der vorhandene Release-Prozess unverändert bleibt und nur das bereits dokumentierte Schutz-Ruleset erweitert wird.

## Hinweis für Maintainer

Nach dem Merge muss die aktualisierte Datei `gh-rulesets/master-protection.json` in den GitHub-Repository-Einstellungen importiert beziehungsweise auf das aktive Ruleset übertragen werden.