### PR TITLE
fix: Bugreport-Kontexte eindeutig unterscheiden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Fixed
 
+- Bugreports unterscheiden den aktuell gewählten Quellendialog sowie Über-Dialog und Barrierefreiheitserklärung eindeutig im vorbelegten Kontext.
 - Der zweistufige Upload-Widget-Test scrollt zu lazy aufgebauten Pending- und
   Erfolgskarten, bevor er deren Darstellung prüft.
 - Bildquellen-Widget-Tests machen gescrollte Aktionsbuttons vor dem Tap

--- a/lib/screens/source_form_screen.dart
+++ b/lib/screens/source_form_screen.dart
@@ -451,9 +451,7 @@ class _SourceFormScreenState extends State<SourceFormScreen> {
             icon: const Icon(Icons.settings),
           ),
           AppSupportMenu(
-            contextName: sharedContent == null
-                ? 'Quellenformular'
-                : 'Geteilten Inhalt erfassen',
+            contextName: 'Quellendialog – ${template.name}',
           ),
         ],
       ),

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -123,7 +123,7 @@ Future<void> showAppAbout(
       ),
       actions: [
         BugReportButton(
-          contextName: 'About-Dialog',
+          contextName: 'Über-Dialog',
           appInfoGateway: gateway,
           externalUrlService: externalUrlService,
         ),

--- a/test/app_support_test.dart
+++ b/test/app_support_test.dart
@@ -32,11 +32,23 @@ void main() {
 
     expect(find.text('Releaseversion 1.2.3+45'), findsOneWidget);
     expect(find.text('Barrierefreiheitserklärung'), findsOneWidget);
+    expect(
+      tester.widget<BugReportButton>(
+        find.byType(BugReportButton),
+      ).contextName,
+      'Über-Dialog',
+    );
 
     await tester.tap(find.text('Barrierefreiheitserklärung'));
     await tester.pumpAndSettle();
     expect(find.text('Bekannte Barrieren'), findsOneWidget);
     expect(find.text('Bug melden'), findsWidgets);
+    expect(
+      tester
+          .widgetList<BugReportButton>(find.byType(BugReportButton))
+          .map((button) => button.contextName),
+      contains('Barrierefreiheitserklärung'),
+    );
   });
 
   testWidgets('bug report requires type and opens prefilled app issue', (

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -51,7 +51,10 @@ void main() {
   ) async {
     await tester.pumpWidget(
       const MaterialApp(
-        home: SourceFormScreen(initialTemplate: imageSourceTemplate),
+        home: SourceFormScreen(
+          key: ValueKey('image-source-dialog'),
+          initialTemplate: imageSourceTemplate,
+        ),
       ),
     );
 
@@ -62,7 +65,10 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        home: SourceFormScreen(initialTemplate: sourceTemplates[3]),
+        home: SourceFormScreen(
+          key: const ValueKey('private-person-dialog'),
+          initialTemplate: sourceTemplates[3],
+        ),
       ),
     );
 

--- a/test/source_form_screen_test.dart
+++ b/test/source_form_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:developer_wiki_source_capture/models/source_template.dart';
 import 'package:developer_wiki_source_capture/screens/source_form_screen.dart';
 import 'package:developer_wiki_source_capture/services/image_input_service.dart';
 import 'package:developer_wiki_source_capture/services/image_upload_service.dart';
+import 'package:developer_wiki_source_capture/widgets/app_support.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -45,6 +46,32 @@ Future<void> pumpUntilNotFound(
 }
 
 void main() {
+  testWidgets('bug report context identifies the selected source dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: SourceFormScreen(initialTemplate: imageSourceTemplate),
+      ),
+    );
+
+    expect(
+      tester.widget<AppSupportMenu>(find.byType(AppSupportMenu)).contextName,
+      'Quellendialog – 🖼️ Bild-Quelle',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SourceFormScreen(initialTemplate: sourceTemplates[3]),
+      ),
+    );
+
+    expect(
+      tester.widget<AppSupportMenu>(find.byType(AppSupportMenu)).contextName,
+      'Quellendialog – 🔒 Privatperson fürs Wiki',
+    );
+  });
+
   testWidgets('shows a temporary hint when validation fails', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Zusammenfassung

Bugreports enthalten jetzt einen eindeutig unterscheidbaren Kontext für den tatsächlich genutzten Quellen- oder Supportdialog.

### Quellenformulare

Der Kontext wird dynamisch aus dem aktuell ausgewählten Quellentyp gebildet:

- `Quellendialog – 🖼️ Bild-Quelle`
- `Quellendialog – 🔒 Privatperson fürs Wiki`
- entsprechend auch für alle weiteren vorhandenen und zukünftigen `SourceTemplate`-Namen.

### Supportdialoge

- `Über-Dialog`
- `Barrierefreiheitserklärung`

Fixes #128

## Ursache

`SourceFormScreen` verwendete bisher lediglich den allgemeinen Einstiegskontext `Quellenformular` beziehungsweise `Geteilten Inhalt erfassen`. Der bereits bekannte ausgewählte Quellentyp aus `template.name` wurde nicht weitergereicht. Der Über-Dialog verwendete außerdem die uneinheitliche interne Bezeichnung `About-Dialog`.

## Prüfungen

- Widget-Test unterscheidet Bild-Quelle und Privatperson
- unterschiedliche Widget-Keys erzwingen beim Test einen echten Neuaufbau des zustandsbehafteten Quellenformulars
- Widget-Test prüft den Kontext `Über-Dialog`
- Widget-Test prüft den Kontext `Barrierefreiheitserklärung`
- Kontext fließt weiterhin zentral über `AppSupportMenu` und `BugReportButton`
- keine Secrets, neuen Abhängigkeiten oder zusätzlichen Berechtigungen eingeführt

Die Connector-Arbeitsumgebung enthält weder Flutter noch Dart. `dart format`, `flutter analyze` und `flutter test` müssen daher lokal ausgeführt werden.

## Dokumentation

- `CHANGELOG.md` unter `Unreleased / Fixed` aktualisiert
- README und Architekturdokumentation bleiben unverändert, da Schnittstellen und Architektur nicht geändert wurden.