### PR TITLE
GitHub-Anmeldung für Bugreports transparent kommunizieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Changed
 
+- Der Bugreport weist vor dem Wechsel zu GitHub darauf hin, dass zum endgültigen Absenden eine GitHub-Anmeldung erforderlich ist und der vorbereitete Bericht dort zunächst geprüft werden kann.
 - Das importierbare Branch-Ruleset schützt neben `master` jetzt auch alle Branches unter `release/**`.
 - Einstellungen verwenden jetzt feldnahe Validierung, temporäre Hinweise und reservierten Platz unter den Aktionsschaltflächen.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Zusätzliche Account Permissions sind für den aktuellen Funktionsumfang nicht e
 
 Release-Keystores und daraus erzeugte Base64-Dateien dürfen ebenfalls nicht ins Repository eingecheckt werden.
 
-Der App-Bugreport öffnet ausschließlich eine vorbereitete GitHub-Seite im Browser. Das für das persönliche Wiki gespeicherte PAT wird dabei weder gelesen noch für Zugriffe auf das App-Repository verwendet.
+Der App-Bugreport öffnet ausschließlich eine vorbereitete GitHub-Seite im Browser. Zum endgültigen Absenden ist dort eine Anmeldung bei GitHub erforderlich; der vorbereitete Bericht kann vor dem Absenden geprüft oder verworfen werden. Das für das persönliche Wiki gespeicherte PAT wird dabei weder gelesen noch für Zugriffe auf das App-Repository verwendet.
 
 ## Hintergrund
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -29,10 +29,12 @@ GitHub-Bugreport im Browser:
 
 `https://github.com/Huluvu424242/developer-wiki-app/issues/new`
 
-Der Nutzer kann die Meldung auf GitHub prüfen und endgültig absenden. Das in
-der App gespeicherte PAT des persönlichen Developer-Wikis wird dafür weder
-gelesen noch übertragen. Der Browserablauf setzt das Label `bug` über die
-vorbereitete GitHub-URL.
+Bereits im Bugreport-Dialog wird darauf hingewiesen, dass zum endgültigen
+Absenden eine Anmeldung bei GitHub erforderlich ist. Der Nutzer kann die
+vorbereitete Meldung auf GitHub zunächst prüfen und erst dort endgültig
+absenden oder den Vorgang abbrechen. Das in der App gespeicherte PAT des
+persönlichen Developer-Wikis wird dafür weder gelesen noch übertragen. Der
+Browserablauf setzt das Label `bug` über die vorbereitete GitHub-URL.
 
 Keine Logs, Tokens oder anderen Diagnosedaten werden automatisch beigefügt.
 

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -425,6 +425,15 @@ class _BugReportDialogState extends State<_BugReportDialog> {
                     alignLabelWithHint: true,
                   ),
                 ),
+                const SizedBox(height: 12),
+                const Semantics(
+                  container: true,
+                  child: Text(
+                    'Zum Absenden ist eine Anmeldung bei GitHub erforderlich. '
+                    'Der vorbereitete Bericht kann auf GitHub geprüft und erst '
+                    'dort endgültig abgesendet werden.',
+                  ),
+                ),
                 if (_errorMessage != null) ...[
                   const SizedBox(height: 12),
                   Semantics(

--- a/test/app_support_test.dart
+++ b/test/app_support_test.dart
@@ -78,6 +78,14 @@ void main() {
 
     expect(find.text('Kontext: Quellenformular'), findsOneWidget);
     expect(find.text('Releaseversion: 1.2.3+45'), findsOneWidget);
+    expect(
+      find.text(
+        'Zum Absenden ist eine Anmeldung bei GitHub erforderlich. '
+        'Der vorbereitete Bericht kann auf GitHub geprüft und erst dort '
+        'endgültig abgesendet werden.',
+      ),
+      findsOneWidget,
+    );
 
     await tester.tap(find.text('Auf GitHub prüfen'));
     await tester.pump();


### PR DESCRIPTION
## Zusammenfassung

- ergänzt im Bugreport-Dialog einen sichtbaren und für Screenreader wahrnehmbaren Hinweis, dass zum endgültigen Absenden eine GitHub-Anmeldung erforderlich ist
- stellt klar, dass der vorbereitete Bericht zunächst auf GitHub geprüft und erst dort abgesendet wird
- lässt den bestehenden browserbasierten Ablauf und die Aktion `Auf GitHub prüfen` unverändert
- erweitert den Widget-Test um das neue Wording
- aktualisiert `CHANGELOG.md`, `README.md` und `docs/accessibility.md`

## Architektur und Sicherheit

Es werden keine neuen Authentifizierungsmechanismen, PATs, OAuth-Tokens, GitHub Apps, Backends oder zusätzlichen Abhängigkeiten eingeführt. Die bestehende Trennung zwischen dem PAT des persönlichen Wikis und dem App-Bugreport bleibt unverändert.

## Prüfung

- Branch mit dem damaligen aktuellen `master` verglichen; geändert wurden ausschließlich die fünf erwarteten Dateien
- bestehende Erzeugung der Bugreport-URL und der Testablauf blieben unverändert
- `dart format`, `flutter analyze` und `flutter test` konnten über den GitHub-Connector nicht ausgeführt werden, da das Repository keinen Pull-Request-CI-Workflow besitzt und die verbundene Repository-Schnittstelle keine Flutter-Ausführungsumgebung bereitstellt; diese Prüfungen bleiben daher Teil der lokalen menschlichen Abnahme

## Dokumentation

Aktualisiert wurden:
- `CHANGELOG.md`
- `README.md`
- `docs/accessibility.md`

Eine Aktualisierung des Architekturdiagramms war nicht erforderlich, da die browserbasierte Bugreport-Architektur unverändert blieb.

Closes #130