### PR TITLE
Deutsche Kommunikation und Abschlussstatus für KI-Agenten festlegen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Arbeitsregeln für KI-Assistenten
 
+## Kommunikation mit menschlichen Entwicklern
+
+Jegliche Kommunikation zwischen KI-Agenten und menschlichen Entwicklern erfolgt grundsätzlich in deutscher Sprache.
+
+- Dies gilt insbesondere für direkte Rückmeldungen, Analysen, Planungen, Review-Rückmeldungen und Abschlussmeldungen sowie für vom KI-Agenten formulierte GitHub-Stories, Fehlerreports bzw. Bug-Issues, Pull-Request-Titel und Pull-Request-Beschreibungen.
+- Technische Bezeichner, API-Namen, Dateinamen, Kommandos, Code, Log-Ausgaben und unveränderte externe Zitate dürfen in ihrer technisch notwendigen Originalsprache verbleiben. Der erläuternde Kontext des KI-Agenten bleibt deutsch.
+- Nach Fertigstellung einer Arbeit oder beim Erreichen eines klaren Zwischenstands informiert der KI-Agent den menschlichen Entwickler aktiv über Ergebnis und aktuellen Stand.
+- Die Abschluss- bzw. Zwischenstandsmeldung nennt die durchgeführten Prüfungen sowie bekannte offene Punkte, Risiken oder notwendige manuelle Prüfungen. Wenn noch Arbeit offen ist, wird der nächste sinnvolle Schritt genannt.
+- Neu erstellte oder für den aktuellen Arbeitsstand relevante GitHub-Artefakte werden als direkt aufrufbare Links angeboten. Dies gilt insbesondere für Stories, Fehlerreports bzw. Bug-Issues und Pull Requests.
+- Gehören mehrere GitHub-Artefakte zur konkreten Arbeit, werden alle relevanten Links gemeinsam genannt.
+
 ## Fehlerbehebung
 
 Wenn der Benutzer einen Fehler meldet und um Behebung bittet, ist grundsätzlich folgender Ablauf einzuhalten:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,25 +34,42 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
   `user-attachments`-URL und erst danach Veröffentlichung mit `quelle`.
 - Verbindliche Projektdokumentation unter `docs/` mit C4-orientierter Architekturübersicht.
 - Dokumentationsregeln für Changelog, README und technische Dokumentation im Implementierungsworkflow.
+- Direkt in den Einstellungen aufrufbare Hilfe zum Erstellen eines Fine-grained GitHub PAT mit den benötigten Least-Privilege-Berechtigungen.
+- Dokumentierter Prozess für die menschliche PR-Abnahme und das schrittweise Prüfen und Rebasen gestapelter Branches.
+- Verbindliche PR-Regel zur Verknüpfung vollständig erledigter Stories und Bugs mit GitHub-Closing-Keywords.
 
 ### Changed
 
-- Android-Share-Ziele verwenden eigenständige Launcher-Icons mit unterscheidbaren Overlays für Link, Text und Bild.
+- Android-Teilen-Ziele verwenden unterscheidbare App-Logo-Varianten mit
+  Weltkugel-, Text- beziehungsweise Bild-Overlay.
+- README nach der Struktur von Standard Readme neu gegliedert und mit der weiterführenden Dokumentation verknüpft.
+- Quellenformular ergonomischer gestaltet: zusätzlicher Abstand unter dem Speichern-Button, temporärer Validierungshinweis und Löschaktionen für befüllte Eingabefelder.
+- Android-Release-Prozess um produktive `release/<tagname>`-Wartungsbranches für Bugfixes, Security Updates und Lifecycle-Maßnahmen ergänzt.
+- Provisorisches Android-Launcher-Icon durch das offizielle Developer-Wiki-App-Logo mit Adaptive, Round und Themed Icon ersetzt.
+- Herkunft und Lizenzen des App-Logos sowie wesentlicher Open-Source-Komponenten in `ATTRIBUTIONS.md` dokumentiert.
 
 ### Fixed
 
-- Dialoge zur Fehlererfassung übermitteln jetzt eindeutig unterscheidbare Kontexte für Link-, Text-, Bild- und Personenquellen sowie für Über-Dialog und Barrierefreiheitserklärung.
+- Bugreports unterscheiden den aktuell gewählten Quellendialog sowie Über-Dialog und Barrierefreiheitserklärung eindeutig im vorbelegten Kontext.
+- Der zweistufige Upload-Widget-Test scrollt zu lazy aufgebauten Pending- und
+  Erfolgskarten, bevor er deren Darstellung prüft.
+- Bildquellen-Widget-Tests machen gescrollte Aktionsbuttons vor dem Tap
+  vollständig sichtbar und pumpen anschließend das aktualisierte Layout.
+- Bildquellen-Widget-Tests verwenden eine injizierte synchrone Vorschau und
+  hängen damit weder vom nativen Bild-Codec noch vom Windows-Dateisystem ab.
+- Bildquellen-Widget-Tests verwenden vollständig decodierbare PNG-Testdaten,
+  damit der Bild-Codec unter Windows nicht an einer abgeschnittenen Datei hängt.
+- Bildquellen-Widget-Tests warten zustandsbasiert auf Vorschau-, Pending- und
+  Erfolgszustände, statt bei einem animierten Textcursor mit `pumpAndSettle`
+  bis zum Timeout zu laufen.
+- Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
+- Initiale Share-Intent-Inhalte werden innerhalb der vorgesehenen asynchronen
+  Fehlerbehandlung vollständig abgewartet.
+- Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
+- Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
+- Widget-Test stabilisiert nach dem Scrollen die Sichtbarkeit und das Layout des Speichern-Buttons vor dem Tap.
+- Pflichtfelder werden beim Speichern unabhängig von ihrer aktuellen Sichtbarkeit im scrollbaren Quellenformular geprüft.
+- Snackbar-Widget-Test prüft nur den globalen Validierungshinweis und setzt keine gleichzeitig sichtbaren Inline-Feldfehler voraus.
 
-## [0.1.0+2] - 2026-08-24
-
-### Added
-
-- Bild-Quelle als eigener Quellentyp mit Bildauswahl und GitHub-Attachment-Ablauf.
-- App-Logo und Share-Ziel-Varianten für Link-, Text- und Bildquellen.
-- `ATTRIBUTIONS.md` für lizenzrechtlich relevante ausgelieferte Bestandteile.
-
-## [0.1.0+1] - 2026-08-22
-
-### Added
-
-- Erste veröffentlichte Android-Version der Developer-Wiki-App.
+[Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+3...HEAD
+[0.1.0+3]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+2...v0.1.0+3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Changed
 
+- KI-Agenten kommunizieren mit menschlichen Entwicklern verbindlich auf Deutsch, formulieren insbesondere Stories, Bug-Issues und Pull Requests auf Deutsch und melden nach Arbeiten Ergebnis, Stand und relevante GitHub-Links zurück.
 - Der Bugreport weist vor dem Wechsel zu GitHub darauf hin, dass zum endgültigen Absenden eine GitHub-Anmeldung erforderlich ist und der vorbereitete Bericht dort zunächst geprüft werden kann.
 - Das importierbare Branch-Ruleset schützt neben `master` jetzt auch alle Branches unter `release/**`.
 - Einstellungen verwenden jetzt feldnahe Validierung, temporäre Hinweise und reservierten Platz unter den Aktionsschaltflächen.
@@ -33,42 +34,25 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
   `user-attachments`-URL und erst danach Veröffentlichung mit `quelle`.
 - Verbindliche Projektdokumentation unter `docs/` mit C4-orientierter Architekturübersicht.
 - Dokumentationsregeln für Changelog, README und technische Dokumentation im Implementierungsworkflow.
-- Direkt in den Einstellungen aufrufbare Hilfe zum Erstellen eines Fine-grained GitHub PAT mit den benötigten Least-Privilege-Berechtigungen.
-- Dokumentierter Prozess für die menschliche PR-Abnahme und das schrittweise Prüfen und Rebasen gestapelter Branches.
-- Verbindliche PR-Regel zur Verknüpfung vollständig erledigter Stories und Bugs mit GitHub-Closing-Keywords.
 
 ### Changed
 
-- Android-Teilen-Ziele verwenden unterscheidbare App-Logo-Varianten mit
-  Weltkugel-, Text- beziehungsweise Bild-Overlay.
-- README nach der Struktur von Standard Readme neu gegliedert und mit der weiterführenden Dokumentation verknüpft.
-- Quellenformular ergonomischer gestaltet: zusätzlicher Abstand unter dem Speichern-Button, temporärer Validierungshinweis und Löschaktionen für befüllte Eingabefelder.
-- Android-Release-Prozess um produktive `release/<tagname>`-Wartungsbranches für Bugfixes, Security Updates und Lifecycle-Maßnahmen ergänzt.
-- Provisorisches Android-Launcher-Icon durch das offizielle Developer-Wiki-App-Logo mit Adaptive, Round und Themed Icon ersetzt.
-- Herkunft und Lizenzen des App-Logos sowie wesentlicher Open-Source-Komponenten in `ATTRIBUTIONS.md` dokumentiert.
+- Android-Share-Ziele verwenden eigenständige Launcher-Icons mit unterscheidbaren Overlays für Link, Text und Bild.
 
 ### Fixed
 
-- Bugreports unterscheiden den aktuell gewählten Quellendialog sowie Über-Dialog und Barrierefreiheitserklärung eindeutig im vorbelegten Kontext.
-- Der zweistufige Upload-Widget-Test scrollt zu lazy aufgebauten Pending- und
-  Erfolgskarten, bevor er deren Darstellung prüft.
-- Bildquellen-Widget-Tests machen gescrollte Aktionsbuttons vor dem Tap
-  vollständig sichtbar und pumpen anschließend das aktualisierte Layout.
-- Bildquellen-Widget-Tests verwenden eine injizierte synchrone Vorschau und
-  hängen damit weder vom nativen Bild-Codec noch vom Windows-Dateisystem ab.
-- Bildquellen-Widget-Tests verwenden vollständig decodierbare PNG-Testdaten,
-  damit der Bild-Codec unter Windows nicht an einer abgeschnittenen Datei hängt.
-- Bildquellen-Widget-Tests warten zustandsbasiert auf Vorschau-, Pending- und
-  Erfolgszustände, statt bei einem animierten Textcursor mit `pumpAndSettle`
-  bis zum Timeout zu laufen.
-- Widget-Test für den Validierungshinweis wartet zustandsbasiert auf die Snackbar statt auf eine feste Verzögerung.
-- Initiale Share-Intent-Inhalte werden innerhalb der vorgesehenen asynchronen
-  Fehlerbehandlung vollständig abgewartet.
-- Widget-Test adressiert den Speichern-Button über einen stabilen Key statt über die konkrete Button-Implementierung.
-- Widget-Test scrollt bis zum lazily aufgebauten Speichern-Button, bevor er ihn antippt.
-- Widget-Test stabilisiert nach dem Scrollen die Sichtbarkeit und das Layout des Speichern-Buttons vor dem Tap.
-- Pflichtfelder werden beim Speichern unabhängig von ihrer aktuellen Sichtbarkeit im scrollbaren Quellenformular geprüft.
-- Snackbar-Widget-Test prüft nur den globalen Validierungshinweis und setzt keine gleichzeitig sichtbaren Inline-Feldfehler voraus.
+- Dialoge zur Fehlererfassung übermitteln jetzt eindeutig unterscheidbare Kontexte für Link-, Text-, Bild- und Personenquellen sowie für Über-Dialog und Barrierefreiheitserklärung.
 
-[Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+3...HEAD
-[0.1.0+3]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+2...v0.1.0+3
+## [0.1.0+2] - 2026-08-24
+
+### Added
+
+- Bild-Quelle als eigener Quellentyp mit Bildauswahl und GitHub-Attachment-Ablauf.
+- App-Logo und Share-Ziel-Varianten für Link-, Text- und Bildquellen.
+- `ATTRIBUTIONS.md` für lizenzrechtlich relevante ausgelieferte Bestandteile.
+
+## [0.1.0+1] - 2026-08-22
+
+### Added
+
+- Erste veröffentlichte Android-Version der Developer-Wiki-App.


### PR DESCRIPTION
## Zusammenfassung

- ergänzt in `AGENTS.md` einen eigenen Abschnitt zur Kommunikation zwischen KI-Agenten und menschlichen Entwicklern
- legt Deutsch als verbindliche Sprache für direkte Kommunikation, Stories, Bug-Issues, PR-Titel und PR-Beschreibungen, Reviews sowie Ergebnisberichte fest
- erlaubt technisch notwendige Originalsprache für Code, Kommandos, API-Namen, Logs und unveränderte externe Zitate
- verpflichtet KI-Agenten nach Arbeiten oder klaren Zwischenständen zu einer Rückmeldung über Ergebnis, Stand, Prüfungen, offene Punkte und gegebenenfalls den nächsten Schritt
- verpflichtet zur Bereitstellung direkt aufrufbarer Links für relevante Stories, Bug-Issues und Pull Requests
- dokumentiert die maintainerrelevante Regeländerung unter `Unreleased` im `CHANGELOG.md`

## Prüfung

- Akzeptanzkriterien aus Story #132 gegen die Ergänzung geprüft
- bestehende Workflow-, Sicherheits-, Dokumentations-, Rebase-, UX- und Architekturregeln in `AGENTS.md` bleiben erhalten
- keine Änderung am Anwendungscode und keine neuen Abhängigkeiten
- Flutter-Formatierung, Analyse und Tests sind für diese reine Markdown-Regeländerung nicht betroffen

## Dokumentation

Aktualisiert wurden:
- `AGENTS.md`
- `CHANGELOG.md`

README und technische Dokumentation unter `docs/` sind nicht betroffen, da weder Nutzung noch Architektur der Anwendung geändert werden.

Closes #132