### PR TITLE
Fachliche Projektstruktur und domänengerechte Benennung festlegen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,17 @@ Jegliche Kommunikation zwischen KI-Agenten und menschlichen Entwicklern erfolgt 
 - Neu erstellte oder für den aktuellen Arbeitsstand relevante GitHub-Artefakte werden als direkt aufrufbare Links angeboten. Dies gilt insbesondere für Stories, Fehlerreports bzw. Bug-Issues und Pull Requests.
 - Gehören mehrere GitHub-Artefakte zur konkreten Arbeit, werden alle relevanten Links gemeinsam genannt.
 
+### Sprache von Bezeichnern im Projekt
+
+Für Bezeichner in Quellcode, Dateinamen, Modellen, Services und anderen technischen Artefakten gilt fachliche Präzision vor sprachlicher Vereinheitlichung.
+
+- Technische Begriffe dürfen und sollen in ihrer etablierten englischen Fachsprache verwendet werden, wenn dies der üblichen Bedeutung in Flutter, Dart, APIs, Protokollen, Architektur oder Softwareentwicklung entspricht.
+- Fachliche Begriffe werden bevorzugt in der Sprache der jeweiligen Fachdomäne benannt. Begriffe einer deutschsprachigen Fachdomäne sollen daher deutsch formuliert werden, wenn sich ihre fachliche Bedeutung dadurch präziser und ohne Informationsverlust ausdrücken lässt.
+- Begriffe dürfen nicht mechanisch übersetzt oder eingedeutscht werden. Eine technische `Editor`-Komponente bleibt beispielsweise `Editor`, solange tatsächlich ein Editor gemeint ist; `Redakteur` beziehungsweise eine daraus gebildete Komponente ist nur passend, wenn die Fachdomäne tatsächlich einen Redakteur beschreibt.
+- Bei Mischbegriffen hat die fachlich korrekte Bedeutung Vorrang vor einer rein deutschen oder rein englischen Benennung.
+- Technische, sprach- oder frameworktypische Präfixe und Konventionen wie `get...`, `set...` und `is...` bleiben erhalten. Sie dürfen nicht aus Gründen sprachlicher Vereinheitlichung umbenannt werden, wenn sie Teil etablierter Sprachsemantik, Tooling-, Framework-, Serialisierungs-, Reflection- oder API-Konventionen sind.
+- Die bestehenden Dart-/Flutter-Namenskonventionen wie `UpperCamelCase`, `lowerCamelCase` und `snake_case.dart` bleiben unabhängig von der Sprache eines fachlichen Begriffs verbindlich.
+
 ## Fehlerbehebung
 
 Wenn der Benutzer einen Fehler meldet und um Behebung bittet, ist grundsätzlich folgender Ablauf einzuhalten:
@@ -145,6 +156,7 @@ Wenn der Benutzer die Umsetzung einer Story beauftragt, ist grundsätzlich folge
     - Keine unnötig langen oder komprimierten Codezeilen erzeugen.
     - Kommentare sollen vor allem das Warum erklären und nicht offensichtlichen Code wiederholen.
     - Strukturierte Daten bevorzugt über klar benannte Modelle statt über lose Maps durch mehrere Schichten reichen.
+    - Für die Sprache fachlicher und technischer Bezeichner gilt zusätzlich der Abschnitt `Sprache von Bezeichnern im Projekt`.
 
 6. Fehler- und Zustandsbehandlung robust umsetzen.
     - Lade-, Erfolgs-, Leer- und Fehlerzustände sichtbar und verständlich behandeln, sofern sie für die Story relevant sind.
@@ -381,6 +393,30 @@ Für alle Screens, Seiten, Formulare und Dialoge der App gelten folgende Regeln 
 ## Architekturleitplanken
 
 Für die Weiterentwicklung der App gelten zusätzlich folgende Leitplanken:
+
+### Fachlich geschnittene Projektstruktur
+
+Die Struktur der eigentlichen Anwendung richtet sich grundsätzlich zuerst nach fachlichen Features beziehungsweise Komponenten und erst innerhalb dieser fachlichen Einheiten nach technischen Rollen. Ziel ist hohe fachliche Kohäsion: Zusammengehörige Funktionalität soll gemeinsam auffindbar und möglichst als fachliche Einheit verschiebbar, kopierbar oder herauslösbar sein.
+
+Beispiel für eine fachlich eigenständige Fehlerberichtsfunktion:
+
+```text
+lib/
+  bugreport/
+    screens/
+    services/
+    models/
+    widgets/
+```
+
+- Globale technische Ordner wie `screens/`, `services/` oder `models/` sollen nicht der primäre Schnitt für fachlich eigenständige Features sein. Technische Unterordner sind innerhalb eines fachlichen Ordners zulässig und sinnvoll, wenn Umfang und Übersichtlichkeit dies rechtfertigen.
+- Kleine fachliche Features dürfen flach bleiben. Technische Unterordner werden nicht vorsorglich angelegt und dürfen keine künstliche Verschachtelung erzeugen.
+- Wird ein fachliches Feature zu groß, ist zuerst fachlich weiter zu schneiden: Ein Teilfeature kann als fachlich benannter Unterordner innerhalb des bisherigen Features ausgegliedert oder als eigenständiges fachliches Feature auf dieselbe Ebene gehoben werden.
+- Ein fachlicher Ordner darf deshalb sowohl technisch benannte Unterordner wie `screens/`, `services/`, `models/` oder `widgets/` als auch weitere fachlich benannte Unterordner enthalten.
+- Flutter-/Dart-Konventionen und technisch vorgegebene Projektbereiche wie `lib/`, `test/`, `android/`, `ios/`, `assets/` und vergleichbare Plattform-, Build- und Tooling-Strukturen bleiben erhalten. Die fachliche Strukturierung findet innerhalb der dafür geeigneten Anwendungsbereiche statt und ersetzt keine Flutter-Konvention.
+- Projektweit tatsächlich gemeinsame technische Infrastruktur darf zentral organisiert werden, wenn sie keiner einzelnen fachlichen Komponente sinnvoll gehört. Eine solche zentrale Ablage darf nicht als Begründung dienen, feature-lokale Fachlogik wieder nach technischen Schichten über das gesamte Projekt zu verteilen.
+- Tests sollen die fachliche Struktur der Anwendung soweit sinnvoll spiegeln, damit Implementierung und zugehörige Tests gemeinsam auffindbar bleiben.
+- Bestehender Code muss nicht in einer Big-Bang-Migration umgebaut werden. Bei neuen Features und gezielten Refactorings soll die Struktur schrittweise in diese Richtung entwickelt werden, sofern dies den vereinbarten Story- oder Bugfix-Umfang nicht unangemessen vergrößert.
 
 - Die App ist ein Client des persönlichen Developer-Wikis, nicht das Wiki selbst. Quellen erfassen, GitHub-Issues erzeugen und Wiki-Workflows auslösen gehören in die App; Importlogik, Archivierung und Wissensaufbereitung bleiben im Wiki-Repository.
 - Eine fachliche Funktion soll einen zentralen Implementierungsweg besitzen. Unterschiedliche Einstiegspunkte wie normale Erfassung und Android-Share sollen dieselbe Fachlogik wiederverwenden.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ### Changed
 
+- Die Architekturleitplanken strukturieren Anwendungscode künftig zuerst nach fachlichen Features und erst innerhalb dieser Features nach technischen Rollen; Bezeichner unterscheiden bewusst zwischen technischer englischer Terminologie und der Sprache der Fachdomäne.
 - KI-Agenten kommunizieren mit menschlichen Entwicklern verbindlich auf Deutsch, formulieren insbesondere Stories, Bug-Issues und Pull Requests auf Deutsch und melden nach Arbeiten Ergebnis, Stand und relevante GitHub-Links zurück.
 - Der Bugreport weist vor dem Wechsel zu GitHub darauf hin, dass zum endgültigen Absenden eine GitHub-Anmeldung erforderlich ist und der vorbereitete Bericht dort zunächst geprüft werden kann.
 - Das importierbare Branch-Ruleset schützt neben `master` jetzt auch alle Branches unter `release/**`.


### PR DESCRIPTION
## Zusammenfassung

- ergänzt die `AGENTS.md` um eine verbindliche Feature-first-Regel: Anwendungscode wird zuerst nach fachlichen Komponenten und erst innerhalb dieser Komponenten nach technischen Rollen gegliedert
- dokumentiert am Beispiel `bugreport/` die mögliche Unterteilung in `screens/`, `services/`, `models/` und `widgets/`
- regelt die weitere fachliche Zerlegung zu groß werdender Features durch fachliche Unterfeatures oder eigenständige Features auf gleicher Ebene
- erhält Flutter-/Dart-Standardstrukturen wie `lib/`, `test/`, `android/`, `ios/` und `assets/` sowie projektweit tatsächlich gemeinsame technische Infrastruktur
- vermeidet künstliche Verschachtelung und verlangt keine Big-Bang-Migration des bestehenden Codes
- legt fest, dass Tests die fachliche Struktur soweit sinnvoll spiegeln
- ergänzt die Benennungsregeln: technische Terminologie darf etabliertes Englisch verwenden, Fachbegriffe richten sich nach der Sprache der Fachdomäne
- schützt etablierte Sprach-, Framework- und API-Konventionen wie `get...`, `set...` und `is...` vor sprachlich motivierter Umbenennung
- dokumentiert die maintainerrelevante Änderung unter `Unreleased` im `CHANGELOG.md`

## Architekturentscheidung

Die Vorgabe wird bewusst mit Flutter harmonisiert. Die fachliche Strukturierung gilt innerhalb der geeigneten Anwendungsbereiche und ersetzt weder Flutter-Projektkonventionen noch technisch notwendige Plattform-, Build- oder Tooling-Strukturen. Kleine Features dürfen flach bleiben; technische Unterordner werden nur angelegt, wenn sie Übersicht schaffen.

Dieser Pull Request strukturiert den bestehenden `lib/`-Baum nicht um. Ein größerer Umbau bestehender Features wäre separat zu analysieren und zu planen.

## Prüfung

- Akzeptanzkriterien aus Story #134 gegen die Änderungen geprüft
- die bestehenden Kommunikations-, Workflow-, Sicherheits-, Dokumentations-, Test-, Rebase-, UX- und Barrierefreiheitsregeln bleiben erhalten
- bestehende Dart-/Flutter-Namenskonventionen bleiben unverändert verbindlich
- keine Änderung am Anwendungscode und keine neuen Abhängigkeiten
- `dart format`, `flutter analyze` und `flutter test` sind für diese reine Markdown-Regeländerung nicht betroffen

## Dokumentation

Aktualisiert wurden:
- `AGENTS.md`
- `CHANGELOG.md`

README und technische Dokumentation unter `docs/` wurden nicht geändert, da dieser PR eine Entwicklungsleitplanke definiert, aber weder Nutzung noch Laufzeitarchitektur der App verändert.

Closes #134