### PR TITLE
Analyzer-Fehler im Bugreport-Semantics beheben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 - Das importierbare Branch-Ruleset schützt neben `master` jetzt auch alle Branches unter `release/**`.
 - Einstellungen verwenden jetzt feldnahe Validierung, temporäre Hinweise und reservierten Platz unter den Aktionsschaltflächen.
 
+### Fixed
+
+- Der GitHub-Anmeldehinweis im Bugreport verwendet kein unzulässiges `const` mehr am `Semantics`-Widget, sodass `flutter analyze` nicht mehr mit `const_with_non_const` abbricht.
+
 ## [0.1.0+3] - 2026-08-25
 
 ### Added

--- a/lib/widgets/app_support.dart
+++ b/lib/widgets/app_support.dart
@@ -426,9 +426,9 @@ class _BugReportDialogState extends State<_BugReportDialog> {
                   ),
                 ),
                 const SizedBox(height: 12),
-                const Semantics(
+                Semantics(
                   container: true,
-                  child: Text(
+                  child: const Text(
                     'Zum Absenden ist eine Anmeldung bei GitHub erforderlich. '
                     'Der vorbereitete Bericht kann auf GitHub geprüft und erst '
                     'dort endgültig abgesendet werden.',


### PR DESCRIPTION
## Zusammenfassung

- entfernt den unzulässigen `const`-Modifier vor dem `Semantics`-Widget des GitHub-Anmeldehinweises im Bugreport
- belässt den statischen Hinweistext selbst als `const Text`
- verändert weder Wording noch Semantik oder Ablauf des Bugreports
- dokumentiert den Analyzer-Fix unter `Unreleased / Fixed` im `CHANGELOG.md`

## Ursache

Die verwendete Flutter-Version stellt den an dieser Stelle verwendeten `Semantics`-Konstruktor nicht als `const` bereit. Dadurch meldet `flutter analyze` in `lib/widgets/app_support.dart` den Fehler `const_with_non_const`.

## Prüfung

- Diff gegen den aktuellen `master` geprüft: geändert werden ausschließlich `lib/widgets/app_support.dart` und `CHANGELOG.md`
- die fachliche Bugreport-Logik und der vorhandene Hinweistext bleiben unverändert
- bestehende Widget-Tests für den Bugreport werden nicht verändert
- `flutter analyze` und `flutter test` konnten über den GitHub-Connector nicht ausgeführt werden; die lokale Prüfung durch den menschlichen Entwickler bleibt daher erforderlich

## Dokumentation

- `CHANGELOG.md` wurde unter `Unreleased / Fixed` ergänzt
- README und weitere Dokumentation unter `docs/` sind nicht betroffen, da sich weder Nutzung noch Architektur verändern

Closes #136