### PR TITLE
Release 0.1.0+4 vorbereiten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.1.0+4] - 2026-08-28
+
 ### Added
 
 - Appweites Menü mit About-Dialog, installierter Release- und Buildnummer sowie offline verfügbarer Barrierefreiheitserklärung.
@@ -76,5 +78,6 @@ und dieses Projekt verwendet [Semantic Versioning](https://semver.org/lang/de/).
 - Pflichtfelder werden beim Speichern unabhängig von ihrer aktuellen Sichtbarkeit im scrollbaren Quellenformular geprüft.
 - Snackbar-Widget-Test prüft nur den globalen Validierungshinweis und setzt keine gleichzeitig sichtbaren Inline-Feldfehler voraus.
 
-[Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+3...HEAD
+[Unreleased]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+4...HEAD
+[0.1.0+4]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+3...v0.1.0+4
 [0.1.0+3]: https://github.com/Huluvu424242/developer-wiki-app/compare/v0.1.0+2...v0.1.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: developer_wiki_source_capture
 description: Android-App zur strukturierten Erfassung von Quellen-Issues im Developer-Wiki.
 publish_to: none
-version: 0.1.0+3
+version: 0.1.0+4
 environment:
   sdk: '>=3.4.0 <4.0.0'
 dependencies:


### PR DESCRIPTION
## Zusammenfassung

- erhöht die App-Version in `pubspec.yaml` von `0.1.0+3` auf `0.1.0+4`
- schließt die bisher unter `Unreleased` dokumentierten Änderungen als Release `0.1.0+4` mit Datum `2026-08-28` ab
- legt oberhalb des Releaseabschnitts wieder einen leeren `Unreleased`-Bereich für kommende Änderungen an
- aktualisiert die Changelog-Vergleichslinks für `Unreleased` und `0.1.0+4`
- verändert weder Anwendungscode noch Abhängigkeiten

## Release-Stand

Das letzte veröffentlichte Release ist `v0.1.0+3`. Dieser Pull Request bereitet ausschließlich die Repository-Metadaten für `0.1.0+4` vor und veröffentlicht noch keine APK.

## Prüfung

- Diff gegen den aktuellen `master` geprüft
- geändert werden ausschließlich `pubspec.yaml` und `CHANGELOG.md`
- `pubspec.yaml` enthält exakt `version: 0.1.0+4`
- der bestehende Abschnitt `0.1.0+3` bleibt erhalten
- keine Anwendungscode- oder Dependency-Änderungen

`flutter analyze` und `flutter test` werden durch diesen Metadaten-PR nicht inhaltlich verändert. Vor dem eigentlichen Release sollen sie gemäß Release-Dokumentation dennoch erfolgreich laufen; der Release-Workflow führt beide Prüfungen ebenfalls aus.

## Nächster Schritt nach dem Merge

Nach dem Merge diesen Pull Requests in GitHub unter **Actions → Android Release APK → Run workflow** den Workflow mit

```text
release_version = 0.1.0+4
```

starten und passende Release Notes angeben.

Der Workflow prüft die Versionskonsistenz, führt `flutter analyze` und `flutter test` aus, baut die signierte APK und veröffentlicht das GitHub Release `v0.1.0+4`.

Erst nach erfolgreichem Release wird gemäß `docs/android-release.md` vom erzeugten Tag `v0.1.0+4` der Wartungsbranch `release/v0.1.0+4` angelegt.

## Dokumentation

Aktualisiert wurde ausschließlich der für das Release maßgebliche `CHANGELOG.md`. `docs/android-release.md` bleibt unverändert, da der bestehende Release-Prozess weiterhin gültig ist.

Closes #138